### PR TITLE
[Main] Add new peering module for cross-account peering

### DIFF
--- a/modules/aws/VPC-Peering-Cross-Account/outputs.tf
+++ b/modules/aws/VPC-Peering-Cross-Account/outputs.tf
@@ -1,0 +1,15 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "peering_id" {
+  value      = aws_vpc_peering_connection.vpc_peering_connection.id
+  depends_on = [aws_vpc_peering_connection.vpc_peering_connection]
+}

--- a/modules/aws/VPC-Peering-Cross-Account/peering.tf
+++ b/modules/aws/VPC-Peering-Cross-Account/peering.tf
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "aws_vpc_peering_connection" "vpc_peering_connection" {
+  peer_owner_id = var.peer_owner_id
+  peer_vpc_id   = var.peer_vpc_id
+  vpc_id        = var.vpc_id
+  auto_accept   = var.auto_accept
+  peer_region   = var.peer_region
+}

--- a/modules/aws/VPC-Peering-Cross-Account/variables.tf
+++ b/modules/aws/VPC-Peering-Cross-Account/variables.tf
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "peer_owner_id" {
+  type        = string
+  description = "Owner ID of the peering network"
+  default     = null
+}
+variable "peer_vpc_id" {
+  type        = string
+  description = "VPC Id of the peering network"
+}
+variable "vpc_id" {
+  type        = string
+  description = "VPC Id of the peering network"
+}
+variable "auto_accept" {
+  type        = bool
+  description = "Auto accept connection from the peering network, Peer should be in the same account"
+  default     = false
+}
+variable "peer_region" {
+  type        = string
+  description = "The region of the accepter VPC of the VPC Peering Connection. auto_accept must be false, and use the aws_vpc_peering_connection_accepter to manage the accepter side."
+  default     = null
+}


### PR DESCRIPTION
## Purpose
Current module used for peering does not support cross-account peering since in that case the peering connection acts as a 'request' and goes to a pending state when the peering is first created. It cannot be modified in any way until it is accepted from the destination side.

The new peering module has no additional modifications that may happen right after peering connections are created. This way the peering connection goes as a request until it is accepted.