### PR TITLE
Add AWS MQ module

### DIFF
--- a/modules/aws/MQ/aws_mq_broker.tf
+++ b/modules/aws/MQ/aws_mq_broker.tf
@@ -1,0 +1,25 @@
+resource "aws_mq_broker" "mq" {
+  broker_name = join("-", [var.project, var.application, var.environment, var.region, "mq"])
+
+  engine_type = "ActiveMQ"
+  engine_version = var.engine_version
+  host_instance_type = var.instance_type
+  security_groups = var.security_group_ids
+  subnet_ids = var.subnet_ids
+  publicly_accessible = var.public_access
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+
+  dynamic "user" {
+    for_each = var.users
+    content {
+      username = user.value.username
+      password = user.value.password
+      console_access = user.value.console_access
+    }
+  }
+
+  logs {
+    audit = var.audit_logs_enabled
+    general = var.general_logs_enabled
+  }
+}

--- a/modules/aws/MQ/outputs.tf
+++ b/modules/aws/MQ/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_mq_broker_name" {
+  value = aws_mq_broker.mq.broker_name
+}

--- a/modules/aws/MQ/variables.tf
+++ b/modules/aws/MQ/variables.tf
@@ -1,0 +1,54 @@
+variable "project" {
+  type        = string
+  description = "Name of the project"
+}
+variable "environment" {
+  type        = string
+  description = "Name of the environment"
+}
+variable "region" {
+  type        = string
+  description = "Code of the region"
+}
+variable "application" {
+  type        = string
+  description = "Purpose of the EKS Cluster"
+}
+variable "engine_version" {
+  type = string
+}
+variable "instance_type" {
+  type = string
+}
+variable "security_group_ids" {
+  type = list(string)
+  default = null
+}
+variable "audit_logs_enabled" {
+  type = bool
+  default = false
+}
+variable "general_logs_enabled" {
+  type = bool
+  default = false
+}
+variable "users" {
+  type = list(object({
+    username = string
+    password = string
+    console_access = bool
+  }))
+  default = []
+}
+variable "subnet_ids" {
+  type = list(string)
+  default = []
+}
+variable "public_access" {
+  type = bool
+  default = false
+}
+variable "auto_minor_version_upgrade" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
## Purpose
A customer (UOE) has requested an AmazonMQ instance in their AWS account to be used by the PDP.

[Related Issue](https://github.com/wso2-enterprise/choreo/issues/23652)