### PR TITLE
Add bucket ownership controls to enable private ACL in S3 bucket

### DIFF
--- a/modules/aws/S3-Account/s3_account.tf
+++ b/modules/aws/S3-Account/s3_account.tf
@@ -18,7 +18,16 @@ resource "aws_s3_bucket" "s3_bucket" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.s3_bucket.id
+  rule {
+    object_ownership = var.object_ownership
+  }
+}
+
 resource "aws_s3_bucket_acl" "bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_ownership_controls  ]
+
   bucket = aws_s3_bucket.s3_bucket.id
   acl    = var.acl
 }

--- a/modules/aws/S3-Account/s3_account.tf
+++ b/modules/aws/S3-Account/s3_account.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket_ownership_controls" "s3_bucket_ownership_controls" {
 }
 
 resource "aws_s3_bucket_acl" "bucket_acl" {
-  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_ownership_controls  ]
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_ownership_controls]
 
   bucket = aws_s3_bucket.s3_bucket.id
   acl    = var.acl

--- a/modules/aws/S3-Account/variables.tf
+++ b/modules/aws/S3-Account/variables.tf
@@ -34,6 +34,11 @@ variable "acl" {
   type        = string
   description = "ACL to be applied to the bucket"
 }
+variable "object_ownership" {
+  type        = string
+  description = "Bucket ownership controls"
+  default     = "BucketOwnerPreferred"
+}
 variable "block_public_acls" {
   type        = bool
   description = "Block public access to the bucket"


### PR DESCRIPTION
## Purpose
In the S3 Account, ACL is set to private. To enable the private ACLs rules, the bucket ownership controls should be defined.

## Goals
Have private ACL rules added to S3 bucket

## Approach
Create bucket ownership controls to S3 bucket module, which then can be defined as owner preferred ACL set.