### PR TITLE
Onboard output.tf for Transit-Gateway-Route-Table module

### DIFF
--- a/modules/aws/Transit-Gateway-Route-Table/outputs.tf
+++ b/modules/aws/Transit-Gateway-Route-Table/outputs.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 

--- a/modules/aws/Transit-Gateway-Route-Table/outputs.tf
+++ b/modules/aws/Transit-Gateway-Route-Table/outputs.tf
@@ -1,0 +1,14 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "transit_gateway_route_table_id" {
+  value = aws_ec2_transit_gateway_route_table.ec2_transit_gateway_route_table.id
+}


### PR DESCRIPTION
## Purpose  
Expose `transit_gateway_route_table_id` output in the Transit-Gateway-Route-Table module to make it available for other modules.

## Approach  
- Created `output.tf` inside the Transit-Gateway-Route-Table module.  
- Added `transit_gateway_route_table_id` as an output variable.  