### PR TITLE
Onboard EKS Fargate profile module and update EKS configurations

### DIFF
--- a/modules/aws/EC2-Instance/iam_role.tf
+++ b/modules/aws/EC2-Instance/iam_role.tf
@@ -64,7 +64,7 @@ resource "aws_iam_instance_profile" "iam_instance_profile" {
 resource "aws_iam_role_policy_attachment" "instance_connect" {
   count      = var.enable_instance_connect == true ? 1 : 0
   role       = aws_iam_role.iam_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_role_policy_attachment" "session_manager" {

--- a/modules/aws/EKS-Cluster/eks.tf
+++ b/modules/aws/EKS-Cluster/eks.tf
@@ -35,7 +35,6 @@ resource "aws_eks_cluster" "eks_cluster" {
     bootstrap_cluster_creator_admin_permissions = var.bootstrap_cluster_creator_admin_permissions
   }
 
-
   dynamic "encryption_config" {
     for_each = var.secret_encryption_cmk != null ? [1] : []
     content {

--- a/modules/aws/EKS-Cluster/eks.tf
+++ b/modules/aws/EKS-Cluster/eks.tf
@@ -30,6 +30,12 @@ resource "aws_eks_cluster" "eks_cluster" {
     subnet_ids              = length(var.cluster_subnet_ids) == 0 ? aws_subnet.eks_subnet[*].id : var.cluster_subnet_ids
   }
 
+  access_config {
+    authentication_mode                         = var.authentication_mode
+    bootstrap_cluster_creator_admin_permissions = var.bootstrap_cluster_creator_admin_permissions
+  }
+
+
   dynamic "encryption_config" {
     for_each = var.secret_encryption_cmk != null ? [1] : []
     content {

--- a/modules/aws/EKS-Cluster/outputs.tf
+++ b/modules/aws/EKS-Cluster/outputs.tf
@@ -73,3 +73,7 @@ output "eks_route_table_ids" {
   value      = aws_route_table.route_table[*].id
   depends_on = [aws_route_table.route_table]
 }
+output "eks_security_group_id" {
+  value      = aws_eks_cluster.eks_cluster.vpc_config[0].cluster_security_group_id
+  depends_on = [aws_eks_cluster.eks_cluster]
+}

--- a/modules/aws/EKS-Cluster/variables.tf
+++ b/modules/aws/EKS-Cluster/variables.tf
@@ -119,3 +119,13 @@ variable "cluster_subnet_ids" {
   description = "Subnet IDs for the EKS Cluster"
   default     = []
 }
+variable "authentication_mode" {
+  type        = string
+  description = "EKS Cluster authentication mode"
+  default     = "CONFIG_MAP"
+}
+variable "bootstrap_cluster_creator_admin_permissions" {
+  type        = bool
+  description = "Whether or not to bootstrap the access config values to the cluster"
+  default     = false
+}

--- a/modules/aws/EKS-Fargate-Profile/eks_fargate_profile.tf
+++ b/modules/aws/EKS-Fargate-Profile/eks_fargate_profile.tf
@@ -21,7 +21,7 @@
 resource "aws_eks_fargate_profile" "eks_fargate_profile" {
   cluster_name           = var.eks_cluster_name
   fargate_profile_name   = var.fargate_profile_name
-  pod_execution_role_arn = var.fargate_iam_role_arn == null ? aws_iam_role.iam_role[0].arn : var.fargate_iam_role_arn
+  pod_execution_role_arn = aws_iam_role.iam_role.arn
   subnet_ids             = var.subnet_ids
   tags                   = var.tags
 

--- a/modules/aws/EKS-Fargate-Profile/eks_fargate_profile.tf
+++ b/modules/aws/EKS-Fargate-Profile/eks_fargate_profile.tf
@@ -1,0 +1,38 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "aws_eks_fargate_profile" "eks_fargate_profile" {
+  cluster_name           = var.eks_cluster_name
+  fargate_profile_name   = var.fargate_profile_name
+  pod_execution_role_arn = var.fargate_iam_role_arn == null ? aws_iam_role.iam_role[0].arn : var.fargate_iam_role_arn
+  subnet_ids             = var.subnet_ids
+  tags                   = var.tags
+
+  dynamic "selector" {
+    for_each = var.fargate_namespaces
+    content {
+      namespace = selector.value
+    }
+  }
+
+  depends_on = [
+    aws_iam_role.iam_role
+  ]
+}

--- a/modules/aws/EKS-Fargate-Profile/iam_role.tf
+++ b/modules/aws/EKS-Fargate-Profile/iam_role.tf
@@ -1,0 +1,45 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "aws_iam_role" "iam_role" {
+  count = var.fargate_iam_role_arn != null ? 0 : 1
+  name  = join("-", [var.eks_cluster_name, var.fargate_profile_name, "eks-fargate-profile-iam-role"])
+
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "eks-fargate-pods.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "amazon_eks_fargate_pod_execution_role_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
+  role       = aws_iam_role.iam_role[0].name
+
+  depends_on = [
+    aws_iam_role.iam_role
+  ]
+}

--- a/modules/aws/EKS-Fargate-Profile/iam_role.tf
+++ b/modules/aws/EKS-Fargate-Profile/iam_role.tf
@@ -19,8 +19,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "aws_iam_role" "iam_role" {
-  count = var.fargate_iam_role_arn != null ? 0 : 1
-  name  = join("-", [var.eks_cluster_name, var.fargate_profile_name, "eks-fargate-profile-iam-role"])
+  name = join("-", [var.eks_cluster_name, var.fargate_profile_name, "eks-fargate-profile-iam-role"])
 
   assume_role_policy = jsonencode({
     Statement = [{
@@ -37,7 +36,7 @@ resource "aws_iam_role" "iam_role" {
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_fargate_pod_execution_role_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
-  role       = aws_iam_role.iam_role[0].name
+  role       = aws_iam_role.iam_role.name
 
   depends_on = [
     aws_iam_role.iam_role

--- a/modules/aws/EKS-Fargate-Profile/outputs.tf
+++ b/modules/aws/EKS-Fargate-Profile/outputs.tf
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------

--- a/modules/aws/EKS-Fargate-Profile/variables.tf
+++ b/modules/aws/EKS-Fargate-Profile/variables.tf
@@ -1,0 +1,46 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "fargate_iam_role_arn" {
+  description = "IAM role ARN to be associated with the fargate"
+  type        = string
+  default     = null
+}
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+variable "fargate_profile_name" {
+  description = "Name of the fargate profile"
+  type        = string
+}
+variable "tags" {
+  description = "Tags to be associated with the EKS"
+  type        = map(string)
+  default     = {}
+}
+variable "fargate_namespaces" {
+  description = "Namespaces to be used in Fargate profile"
+  type        = list(string)
+}
+variable "subnet_ids" {
+  description = "List of subnets to deploy nodepools"
+  type        = list(string)
+}

--- a/modules/aws/EKS-Fargate-Profile/variables.tf
+++ b/modules/aws/EKS-Fargate-Profile/variables.tf
@@ -18,12 +18,6 @@
 #
 # --------------------------------------------------------------------------------------
 
-variable "fargate_iam_role_arn" {
-  description = "IAM role ARN to be associated with the fargate"
-  type        = string
-  default     = null
-}
-
 variable "eks_cluster_name" {
   description = "Name of the EKS cluster"
   type        = string

--- a/modules/aws/EKS-Fargate-Profile/variables.tf
+++ b/modules/aws/EKS-Fargate-Profile/variables.tf
@@ -23,23 +23,28 @@ variable "fargate_iam_role_arn" {
   type        = string
   default     = null
 }
+
 variable "eks_cluster_name" {
   description = "Name of the EKS cluster"
   type        = string
 }
+
 variable "fargate_profile_name" {
   description = "Name of the fargate profile"
   type        = string
 }
+
 variable "tags" {
   description = "Tags to be associated with the EKS"
   type        = map(string)
   default     = {}
 }
+
 variable "fargate_namespaces" {
   description = "Namespaces to be used in Fargate profile"
   type        = list(string)
 }
+
 variable "subnet_ids" {
   description = "List of subnets to deploy nodepools"
   type        = list(string)

--- a/modules/aws/EKS-Fargate-Profile/versions.tf
+++ b/modules/aws/EKS-Fargate-Profile/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.3.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Purpose  
Onboard the EKS Fargate Profile module and enhance the EKS module configuration.

## Goals  
- Onboard the `EKS-Fargate-Profile` module to support Fargate workloads within the EKS cluster.  
- Update `EKS-Cluster/outputs.tf` to expose the security group ID created with EKS, enabling additional security rule configurations.  
- Add an `access_config` section in the EKS-Cluster module to configure the authentication mode for the cluster.  
- Introduce two new variables:
  - `authentication_mode`: Allows selection of the authentication mode for the cluster.  
  - `bootstrap_cluster_creator_admin_permissions`: Determines whether to bootstrap the access config values to the cluster with admin permissions.  
- Update `AmazonSSMManagedInstanceCore`policy ARN in EC2 module
