### PR TITLE
Add ACM

### DIFF
--- a/modules/aws/ACM-Certificate/cert.tf
+++ b/modules/aws/ACM-Certificate/cert.tf
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "cert" {
+  domain_name       = var.domain_name
+
+  key_algorithm = var.key_algorithm
+
+  subject_alternative_names = var.subject_alternative_names
+
+  validation_method = var.validation_method
+
+  validation_option {
+    domain_name       = var.domain_name
+    validation_domain = var.validation_domain
+  }
+
+  tags = var.tags
+}

--- a/modules/aws/ACM-Certificate/outputs.tf
+++ b/modules/aws/ACM-Certificate/outputs.tf
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "certificate_arn" {
+  value = aws_acm_certificate.cert.arn
+}
+output "certificate_id" {
+  value = aws_acm_certificate.cert.id
+}

--- a/modules/aws/ACM-Certificate/variables.tf
+++ b/modules/aws/ACM-Certificate/variables.tf
@@ -1,0 +1,37 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "tags" {
+  description = "Tags to be associated with the resource"
+  type = map(string)
+  default = {}
+}
+variable "domain_name" {
+  description = "Domain name"
+  type = string
+}
+variable "subject_alternative_names" {
+  description = "Subject alternative names"
+  type = list(string)
+  default = []
+}
+variable "key_algorithm" {
+  description = "Key algorithm to be used to generate the certificate"
+  type = string
+}
+variable "validation_domain" {
+  description = "Domain name to be used for validation"
+  type = string
+}
+variable "validation_method" {
+  description = "Validation method to be used"
+  type = string
+}


### PR DESCRIPTION
## Purpose
> This pull request re-introduces a new module for managing AWS ACM Certificates. The changes include the creation of resources, outputs, and variables necessary for the ACM Certificate module. The most important changes are summarized below:

## Goals
> The solutions introduced by this feature/fix will enable the creation and management of AWS ACM Certificates through Terraform. This includes defining the necessary resources, outputs, and variables for configuring the ACM Certificate.

## Approach
> The implementation includes the following changes:
> 
> ### New ACM Certificate Resource
> * [`modules/aws/ACM-Certificate/cert.tf`](diffhunk://#diff-a680b90300a061d7fc711abca84b3525540d3d1775d223377eb300c99c647bbaR1-R27): Added a new resource definition for `aws_acm_certificate` with necessary attributes such as `domain_name`, `key_algorithm`, `subject_alternative_names`, `validation_method`, and `validation_option`.
> 
> ### Outputs for ACM Certificate
> * [`modules/aws/ACM-Certificate/outputs.tf`](diffhunk://#diff-9aa735546c493814fb54c8cc0f74026c26c282b069ee856d3f161246a0fd82d3R1-R17): Added outputs to expose the `certificate_arn` and `certificate_id` of the created ACM Certificate.
> 
> ### Variables for ACM Certificate Configuration
> * [`modules/aws/ACM-Certificate/variables.tf`](diffhunk://#diff-4ba13d5cbcda7820b4fec18ca3149a7ad7b04d34aa88afc04f90fa9989d3b7b3R1-R37): Defined variables for configuring the ACM Certificate, including `tags`, `domain_name`, `subject_alternative_names`, `key_algorithm`, `validation_domain`, and `validation_method`.
> 
> ### Copyright Notices
> * Added copyright notices to all modified files to ensure proper attribution and legal protection. [[1]](diffhunk://#diff-a680b90300a061d7fc711abca84b3525540d3d1775d223377eb300c99c647bbaR1-R27) [[2]](diffhunk://#diff-9aa735546c493814fb54c8cc0f74026c26c282b069ee856d3f161246a0fd82d3R1-R17) [[3]](diffhunk://#diff-4ba13d5cbcda7820b4fec18ca3149a7ad7b04d34aa88afc04f90fa9989d3b7b3R1-R37)