### PR TITLE
Add Budget-Alert-Kit

### DIFF
--- a/modules/aws/Budget-Alert-Kit/budget.tf
+++ b/modules/aws/Budget-Alert-Kit/budget.tf
@@ -1,3 +1,14 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
 # Global Budget for all tagged resources
 resource "aws_budgets_budget" "global" {
   name          = "Choreo-global-budget"

--- a/modules/aws/Budget-Alert-Kit/budget.tf
+++ b/modules/aws/Budget-Alert-Kit/budget.tf
@@ -11,13 +11,13 @@
 
 # Global Budget for all tagged resources
 resource "aws_budgets_budget" "global" {
-  name          = "Choreo-global-budget"
-  budget_type   = "COST"
-  limit_amount  = var.cost
-  limit_unit    = "USD"
-  time_unit     = "MONTHLY"
+  name         = "Choreo-global-budget"
+  budget_type  = "COST"
+  limit_amount = var.cost
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
 
-  
+
   cost_filter {
     name   = "TagKeyValue"
     values = ["${var.tag_key}${"$"}${var.tag_value}"]
@@ -42,11 +42,11 @@ resource "aws_budgets_budget" "global" {
 
 # EC2 Instances Budget (configured percentage)
 resource "aws_budgets_budget" "ec2" {
-  name          = "Choreo-EC2-budget"
-  budget_type   = "COST"
-  limit_amount  = local.ec2_limit
-  limit_unit    = "USD"
-  time_unit     = "MONTHLY"
+  name         = "Choreo-EC2-budget"
+  budget_type  = "COST"
+  limit_amount = local.ec2_limit
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
 
 
   cost_filter {
@@ -55,7 +55,7 @@ resource "aws_budgets_budget" "ec2" {
   }
 
   cost_filter {
-    name   = "Service"
+    name = "Service"
     values = [
       "Amazon Elastic Compute Cloud - Compute",
     ]
@@ -80,11 +80,11 @@ resource "aws_budgets_budget" "ec2" {
 
 # Logs Budget (configured percentage, no tag filter)
 resource "aws_budgets_budget" "logs" {
-  name          = "Choreo-Logs-budget"
-  budget_type   = "COST"
-  limit_amount  = local.logs_limit
-  limit_unit    = "USD"
-  time_unit     = "MONTHLY"
+  name         = "Choreo-Logs-budget"
+  budget_type  = "COST"
+  limit_amount = local.logs_limit
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
 
   cost_filter {
     name   = "TagKeyValue"
@@ -92,7 +92,7 @@ resource "aws_budgets_budget" "logs" {
   }
 
   cost_filter {
-    name   = "Service"
+    name = "Service"
     values = [
       "AmazonCloudWatch",
     ]
@@ -116,11 +116,11 @@ resource "aws_budgets_budget" "logs" {
 
 # Networking Budget (configured percentage)
 resource "aws_budgets_budget" "networking" {
-  name          = "Choreo-Networking-budget"
-  budget_type   = "COST"
-  limit_amount  = local.networking_limit
-  limit_unit    = "USD"
-  time_unit     = "MONTHLY"
+  name         = "Choreo-Networking-budget"
+  budget_type  = "COST"
+  limit_amount = local.networking_limit
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
 
   cost_filter {
     name   = "TagKeyValue"
@@ -128,7 +128,7 @@ resource "aws_budgets_budget" "networking" {
   }
 
   cost_filter {
-    name   = "Service"
+    name = "Service"
     values = [
       "AmazonVPC",
     ]

--- a/modules/aws/Budget-Alert-Kit/budget.tf
+++ b/modules/aws/Budget-Alert-Kit/budget.tf
@@ -1,0 +1,141 @@
+# Global Budget for all tagged resources
+resource "aws_budgets_budget" "global" {
+  name          = "Choreo-global-budget"
+  budget_type   = "COST"
+  limit_amount  = var.cost
+  limit_unit    = "USD"
+  time_unit     = "MONTHLY"
+
+  
+  cost_filter {
+    name   = "TagKeyValue"
+    values = ["${var.tag_key}${"$"}${var.tag_value}"]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.critical_sns_arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.warning_sns_arn]
+  }
+}
+
+# EC2 Instances Budget (configured percentage)
+resource "aws_budgets_budget" "ec2" {
+  name          = "Choreo-EC2-budget"
+  budget_type   = "COST"
+  limit_amount  = local.ec2_limit
+  limit_unit    = "USD"
+  time_unit     = "MONTHLY"
+
+
+  cost_filter {
+    name   = "TagKeyValue"
+    values = ["${var.tag_key}${"$"}${var.tag_value}"]
+  }
+
+  cost_filter {
+    name   = "Service"
+    values = [
+      "Amazon Elastic Compute Cloud - Compute",
+    ]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.critical_sns_arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.warning_sns_arn]
+  }
+}
+
+# Logs Budget (configured percentage, no tag filter)
+resource "aws_budgets_budget" "logs" {
+  name          = "Choreo-Logs-budget"
+  budget_type   = "COST"
+  limit_amount  = local.logs_limit
+  limit_unit    = "USD"
+  time_unit     = "MONTHLY"
+
+  cost_filter {
+    name   = "TagKeyValue"
+    values = ["${var.tag_key}${"$"}${var.tag_value}"]
+  }
+
+  cost_filter {
+    name   = "Service"
+    values = [
+      "AmazonCloudWatch",
+    ]
+  }
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.critical_sns_arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.warning_sns_arn]
+  }
+}
+
+# Networking Budget (configured percentage)
+resource "aws_budgets_budget" "networking" {
+  name          = "Choreo-Networking-budget"
+  budget_type   = "COST"
+  limit_amount  = local.networking_limit
+  limit_unit    = "USD"
+  time_unit     = "MONTHLY"
+
+  cost_filter {
+    name   = "TagKeyValue"
+    values = ["${var.tag_key}${"$"}${var.tag_value}"]
+  }
+
+  cost_filter {
+    name   = "Service"
+    values = [
+      "AmazonVPC",
+    ]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.critical_sns_arn]
+  }
+
+  notification {
+    comparison_operator       = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "FORECASTED"
+    subscriber_sns_topic_arns = [var.warning_sns_arn]
+  }
+}

--- a/modules/aws/Budget-Alert-Kit/locals.tf
+++ b/modules/aws/Budget-Alert-Kit/locals.tf
@@ -1,3 +1,14 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
 locals {
   ec2_limit       = var.cost * (var.ec2_percentage / 100)
   logs_limit      = var.cost * (var.logs_percentage / 100)

--- a/modules/aws/Budget-Alert-Kit/locals.tf
+++ b/modules/aws/Budget-Alert-Kit/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  ec2_limit       = var.cost * (var.ec2_percentage / 100)
+  logs_limit      = var.cost * (var.logs_percentage / 100)
+  networking_limit = var.cost * (var.networking_percentage / 100)
+}

--- a/modules/aws/Budget-Alert-Kit/variables.tf
+++ b/modules/aws/Budget-Alert-Kit/variables.tf
@@ -1,3 +1,14 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
 variable "cost" {
   type        = number
   description = "Total monthly budget amount in USD"

--- a/modules/aws/Budget-Alert-Kit/variables.tf
+++ b/modules/aws/Budget-Alert-Kit/variables.tf
@@ -1,0 +1,44 @@
+variable "cost" {
+  type        = number
+  description = "Total monthly budget amount in USD"
+}
+
+variable "tag_key" {
+  type        = string
+  description = "Tag key used to identify Choreo PDP resources"
+  default     = "Managed-By"
+}
+
+variable "tag_value" {
+  type        = string
+  description = "Tag value used to identify Choreo PDP resources"
+  default     = "Choreo-PDP-Terraform-Bot"
+}
+
+variable "critical_sns_arn" {
+  type        = string
+  description = "ARN for critical alerts SNS topic"
+}
+
+variable "warning_sns_arn" {
+  type        = string
+  description = "ARN for warning alerts SNS topic"
+}
+
+variable "ec2_percentage" {
+  type        = number
+  description = "Percentage of total cost allocated for EC2 instances"
+  default     = 60
+}
+
+variable "logs_percentage" {
+  type        = number
+  description = "Percentage of total cost allocated for Cloudwatcg"
+  default     = 20
+}
+
+variable "networking_percentage" {
+  type        = number
+  description = "Percentage of total cost allocated for networking"
+  default     = 20
+}

--- a/modules/aws/Budget-Alert-Kit/variables.tf
+++ b/modules/aws/Budget-Alert-Kit/variables.tf
@@ -33,7 +33,7 @@ variable "ec2_percentage" {
 
 variable "logs_percentage" {
   type        = number
-  description = "Percentage of total cost allocated for Cloudwatcg"
+  description = "Percentage of total cost allocated for Cloudwatch"
   default     = 20
 }
 

--- a/modules/aws/Budget-Alert-Kit/versions.tf
+++ b/modules/aws/Budget-Alert-Kit/versions.tf
@@ -9,8 +9,12 @@
 #
 # --------------------------------------------------------------------------------------
 
-locals {
-  ec2_limit        = var.cost * (var.ec2_percentage / 100)
-  logs_limit       = var.cost * (var.logs_percentage / 100)
-  networking_limit = var.cost * (var.networking_percentage / 100)
+terraform {
+  required_version = ">= 1.3.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
 }


### PR DESCRIPTION
## Purpose

Adds a budget for Key AWS resources with default ratios defined by the SRE team. These can customised/configured on an individual basis when using the module. Key resources covered include: CloudWatch, EC2 and VPCs. The default behaviour is as follows:


Budget alerts trigger when: 

- The projected cost reaches 100% of our budget (Critical) 
- The projected cost reaches 80% of our budget (Warning) 

Budget for individual components

- EC2 instances should count for 60% of the cost
- Logs instance should count for 20% of the cost
- Networking and other components should count for 20% of the cost