### PR TITLE
Add rds skip final snapshot

### DIFF
--- a/modules/aws/RDS-Aurora/rds.tf
+++ b/modules/aws/RDS-Aurora/rds.tf
@@ -62,8 +62,8 @@ resource "aws_rds_cluster" "rds_cluster" {
   cluster_identifier = local.cluster_name
 
   skip_final_snapshot = var.skip_final_snapshot
-  storage_encrypted = var.storage_encrypted
-  kms_key_id        = var.storage_encrypted == true ? var.kms_key_id : null
+  storage_encrypted   = var.storage_encrypted
+  kms_key_id          = var.storage_encrypted == true ? var.kms_key_id : null
 
   dynamic "scaling_configuration" {
     for_each = var.enable_scaling_configuration == true && var.engine_mode == "serverless" ? [1] : []

--- a/modules/aws/RDS-Aurora/variables.tf
+++ b/modules/aws/RDS-Aurora/variables.tf
@@ -207,7 +207,7 @@ variable "vpc_security_group_ids" {
 variable "skip_final_snapshot" {
   type        = bool
   description = "Flag to skip final snapshot"
-  default     = false 
+  default     = false
 }
 variable "storage_encrypted" {
   type        = bool


### PR DESCRIPTION
## Purpose
By default, when deleting an RDS cluster, AWS requires creating a final snapshot unless explicitly skipped. Without setting skip_final_snapshot to true, the cluster cannot be automatically deleted, requiring manual intervention.

## Goal
To enable seamless automation and prevent manual intervention, introduce the skip_final_snapshot option, allowing the RDS cluster to be deleted without requiring a final snapshot.

## Approach
This pull request introduces a new variable and updates the aws_rds_cluster resource to support skipping the final snapshot when deleting an RDS cluster