### PR TITLE
Introduce lifecycle upgrade engine support to RDS and RDS-Aurora modules

### DIFF
--- a/modules/aws/RDS-Aurora/rds.tf
+++ b/modules/aws/RDS-Aurora/rds.tf
@@ -74,6 +74,8 @@ resource "aws_rds_cluster" "rds_cluster" {
 
   skip_final_snapshot = var.skip_final_snapshot
 
+  engine_lifecycle_support = var.engine_lifecycle_support
+
   dynamic "scaling_configuration" {
     for_each = var.enable_scaling_configuration == true && var.engine_mode == "serverless" ? [1] : []
     content {

--- a/modules/aws/RDS-Aurora/variables.tf
+++ b/modules/aws/RDS-Aurora/variables.tf
@@ -198,6 +198,12 @@ variable "cluster_common_performance_insights_enabled" {
   default     = false
 }
 
+variable "engine_lifecycle_support" {
+  description = "The life cycle type for this DB instance."
+  type        = string
+  default     = "open-source-rds-extended-support"
+}
+
 variable "publicly_accessible" {
   description = "Flag to make the DB publicly accessible"
   type        = bool

--- a/modules/aws/RDS/rds.tf
+++ b/modules/aws/RDS/rds.tf
@@ -50,6 +50,9 @@ resource "aws_db_instance" "rds_instance" {
   vpc_security_group_ids = var.vpc_security_group_ids
 
   skip_final_snapshot = var.skip_final_snapshot
+
+  engine_lifecycle_support = var.engine_lifecycle_support
+
   deletion_protection = var.deletion_protection
 
   storage_encrypted = var.storage_encrypted

--- a/modules/aws/RDS/variables.tf
+++ b/modules/aws/RDS/variables.tf
@@ -167,6 +167,12 @@ variable "storage_encrypted" {
   default     = true
 }
 
+variable "engine_lifecycle_support" {
+  description = "The life cycle type for this DB instance."
+  type        = string
+  default     = "open-source-rds-extended-support"
+}
+
 variable "kms_key_id" {
   description = "KMS key id"
   type        = string


### PR DESCRIPTION
# Introduce Engine Support to RDS and RDS-Aurora Modules

## Purpose

This update introduces engine support configuration to both the RDS and RDS-Aurora Terraform modules.

## Changes

- Added a new input variable `engine_lifecycle_support` to RDS and RDS-Aurora modules.
- Default value is set to `"open-source-rds-extended-support"` to enable extended engine support by default.

