### PR TITLE
Update CloudFront and LoadBalancer configurations

### DIFF
--- a/modules/aws/Backup-Infrastructure/main.tf
+++ b/modules/aws/Backup-Infrastructure/main.tf
@@ -221,7 +221,7 @@ resource "aws_s3_bucket_public_access_block" "backup_reports" {
 resource "aws_backup_report_plan" "plan" {
   count = var.enable_backup_reporting ? 1 : 0
 
-  name        = join("-", [var.plan_name, var.plan_abbreviation])
+  name        = join("_", [var.plan_name, var.plan_abbreviation])
   description = "Backup compliance report for the account"
 
   report_delivery_channel {

--- a/modules/aws/Backup-Plan/main.tf
+++ b/modules/aws/Backup-Plan/main.tf
@@ -52,7 +52,7 @@ resource "aws_backup_plan" "backup_plan" {
   tags = merge(
     var.tags,
     {
-      Name      = join("-", [var.backup_plan_name, var.backup_plan_abbreviation])
+      Name      = join("_", [var.backup_plan_name, var.backup_plan_abbreviation])
       Service   = var.service_name
       ManagedBy = "terraform"
     }

--- a/modules/aws/Backup-Plan/main.tf
+++ b/modules/aws/Backup-Plan/main.tf
@@ -19,7 +19,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "aws_backup_plan" "backup_plan" {
-  name = join("-", [var.backup_plan_name, var.backup_plan_abbreviation])
+  name = join("_", [var.backup_plan_name, var.backup_plan_abbreviation])
 
   dynamic "rule" {
     for_each = var.backup_rules

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -30,9 +30,12 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
       origin_ssl_protocols   = var.origin_ssl_protocols
     }
 
-    origin_shield {
-      enabled              = var.origin_shield_enabled
-      origin_shield_region = var.origin_shield_region
+    dynamic "origin_shield" {
+      for_each = var.origin_shield_enabled ? [1] : []
+      content {
+        enabled              = true
+        origin_shield_region = var.origin_shield_region
+      }
     }
   }
 
@@ -54,6 +57,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   default_cache_behavior {
     cache_policy_id            = var.cache_policy_id
     response_headers_policy_id = var.response_headers_policy_id
+    origin_request_policy_id   = var.origin_request_policy_id
     allowed_methods            = var.allowed_methods
     cached_methods             = var.cached_methods
     target_origin_id           = var.origin_id
@@ -85,6 +89,16 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
       cached_methods           = ordered_cache_behavior.value.cached_methods
       cache_policy_id          = ordered_cache_behavior.value.cache_policy_id
       origin_request_policy_id = ordered_cache_behavior.value.origin_request_policy_id
+
+      dynamic "forwarded_values" {
+        for_each = ordered_cache_behavior.value.cache_policy_id == null ? [1] : []
+        content {
+          query_string = true
+          cookies {
+            forward = "none"
+          }
+        }
+      }
     }
   }
 

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -98,7 +98,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   tags = var.tags
 
   viewer_certificate {
-    cloudfront_default_certificate = var.cloudfront_default_certificate
+    cloudfront_default_certificate = var.cloudfront_default_certificate == null
     acm_certificate_arn            = var.cloudfront_acm_certificate_arn
     ssl_support_method             = var.cloudfront_acm_certificate_arn != null ? var.cloudfront_ssl_support_method : null
     minimum_protocol_version       = var.minimum_protocol_version

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -105,4 +105,15 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   web_acl_id = var.web_acl_id
+
+  lifecycle {
+    precondition {
+      condition     = var.cloudfront_default_certificate == false ? var.cloudfront_acm_certificate_arn != null : true
+      error_message = "cloudfront_acm_certificate_arn must be provided when cloudfront_default_certificate is false."
+    }
+    precondition {
+      condition     = var.cloudfront_default_certificate == true ? var.cloudfront_acm_certificate_arn == null : true
+      error_message = "cloudfront_acm_certificate_arn must not be set when cloudfront_default_certificate is true."
+    }
+  }
 }

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -40,10 +40,15 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   is_ipv6_enabled = var.is_ipv6_enabled
   comment         = var.comment
 
-  logging_config {
-    bucket          = var.log_bucket_name
-    include_cookies = var.log_include_cookies
-    prefix          = var.log_prefix
+  aliases = var.aliases
+
+  dynamic "logging_config" {
+    for_each = var.log_bucket_name != null ? [1] : []
+    content {
+      bucket          = var.log_bucket_name
+      include_cookies = var.log_include_cookies
+      prefix          = var.log_prefix
+    }
   }
 
   default_cache_behavior {
@@ -53,11 +58,13 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
     cached_methods             = var.cached_methods
     target_origin_id           = var.origin_id
 
-    forwarded_values {
-      query_string = true
-
-      cookies {
-        forward = "none"
+    dynamic "forwarded_values" {
+      for_each = var.cache_policy_id == null ? [1] : []
+      content {
+        query_string = true
+        cookies {
+          forward = "none"
+        }
       }
     }
 

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -29,6 +29,11 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
       origin_protocol_policy = var.origin_protocol_policy
       origin_ssl_protocols   = var.origin_ssl_protocols
     }
+
+    origin_shield {
+      enabled              = var.origin_shield_enabled
+      origin_shield_region = var.origin_shield_region
+    }
   }
 
   enabled         = var.enabled
@@ -42,9 +47,11 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   }
 
   default_cache_behavior {
-    allowed_methods  = var.allowed_methods
-    cached_methods   = var.cached_methods
-    target_origin_id = var.origin_id
+    cache_policy_id            = var.cache_policy_id
+    response_headers_policy_id = var.response_headers_policy_id
+    allowed_methods            = var.allowed_methods
+    cached_methods             = var.cached_methods
+    target_origin_id           = var.origin_id
 
     forwarded_values {
       query_string = true
@@ -84,7 +91,10 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   tags = var.tags
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = var.cloudfront_default_certificate
+    acm_certificate_arn            = var.cloudfront_acm_certificate_arn
+    ssl_support_method             = var.cloudfront_acm_certificate_arn != null ? var.cloudfront_ssl_support_method : null
+    minimum_protocol_version       = var.minimum_protocol_version
   }
 
   web_acl_id = var.web_acl_id

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -98,7 +98,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   tags = var.tags
 
   viewer_certificate {
-    cloudfront_default_certificate = var.cloudfront_default_certificate == null
+    cloudfront_default_certificate = var.cloudfront_default_certificate
     acm_certificate_arn            = var.cloudfront_acm_certificate_arn
     ssl_support_method             = var.cloudfront_acm_certificate_arn != null ? var.cloudfront_ssl_support_method : null
     minimum_protocol_version       = var.minimum_protocol_version

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -110,7 +110,7 @@ variable "geo_restriction_locations" {
 variable "tags" {
   description = "Tags for the distribution"
   type        = map(string)
-  default = null
+  default     = null
 }
 
 variable "web_acl_id" {

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -127,9 +127,9 @@ variable "ordered_cache_behaviors" {
     cached_methods           = list(string)
     target_origin_id         = string
     viewer_protocol_policy   = string
-    compress                 = string
-    cache_policy_id          = string
-    origin_request_policy_id = string
+    compress                 = bool
+    cache_policy_id          = optional(string)
+    origin_request_policy_id = optional(string)
   }))
   default = []
 }
@@ -184,6 +184,12 @@ variable "response_headers_policy_id" {
 
 variable "cache_policy_id" {
   description = "The ID of the cache policy to associate with the default cache behavior"
+  type        = string
+  default     = null
+}
+
+variable "origin_request_policy_id" {
+  description = "The ID of the origin request policy for the default cache behavior"
   type        = string
   default     = null
 }

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -110,6 +110,7 @@ variable "geo_restriction_locations" {
 variable "tags" {
   description = "Tags for the distribution"
   type        = map(string)
+  default = null
 }
 
 variable "web_acl_id" {

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -148,3 +148,56 @@ variable "log_prefix" {
   description = "An optional string that you want CloudFront to prefix to the access log filenames for this distribution"
   type        = string
 }
+
+variable "aliases" {
+  description = "List of aliases for the CloudFront distribution"
+  type        = list(string)
+  default     = null
+}
+
+variable "cloudfront_default_certificate" {
+  description = "Specifies whether to use the default CloudFront certificate"
+  type        = bool
+  default     = true
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "The ARN of the ACM certificate for the CloudFront distribution"
+  type        = string
+  default     = null
+}
+
+variable "cloudfront_ssl_support_method" {
+  description = "The SSL support method for the CloudFront distribution"
+  type        = string
+  default     = "sni-only"
+}
+
+variable "response_headers_policy_id" {
+  description = "The ID of the response headers policy to associate with the default cache behavior"
+  type        = string
+  default     = null
+}
+
+variable "cache_policy_id" {
+  description = "The ID of the cache policy to associate with the default cache behavior"
+  type        = string
+  default     = null
+}
+
+variable "origin_shield_enabled" {
+  description = "Specifies whether Origin Shield is enabled for the CloudFront distribution"
+  type        = bool
+  default     = false
+}
+
+variable "origin_shield_region" {
+  description = "The AWS region for Origin Shield"
+  type        = string
+}
+
+variable "minimum_protocol_version" {
+  description = "The minimum SSL/TLS protocol version for the CloudFront distribution"
+  type        = string
+  default     = "TLSv1.2_2021"
+}

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -196,6 +196,7 @@ variable "origin_shield_enabled" {
 variable "origin_shield_region" {
   description = "The AWS region for Origin Shield"
   type        = string
+  default     = null
 }
 
 variable "minimum_protocol_version" {

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -204,4 +204,19 @@ variable "minimum_protocol_version" {
   description = "The minimum SSL/TLS protocol version for the CloudFront distribution"
   type        = string
   default     = "TLSv1.2_2021"
+  
+  validation {
+    condition = contains([
+      "SSLv3",
+      "TLSv1",
+      "TLSv1_2016",
+      "TLSv1.1_2016",
+      "TLSv1.2_2018",
+      "TLSv1.2_2019",
+      "TLSv1.2_2021",
+      "TLSv1.2_2025",
+      "TLSv1.3_2025",
+    ], var.minimum_protocol_version)
+    error_message = "minimum_protocol_version must be one of: SSLv3, TLSv1, TLSv1_2016, TLSv1.1_2016, TLSv1.2_2018, TLSv1.2_2019, TLSv1.2_2021, TLSv1.2_2025, TLSv1.3_2025."
+  }
 }

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -136,6 +136,7 @@ variable "ordered_cache_behaviors" {
 variable "log_bucket_name" {
   description = "The S3 bucket name for CloudFront access logs (e.g., mybucket.s3.amazonaws.com)"
   type        = string
+  default     = null
 }
 
 variable "log_include_cookies" {
@@ -147,6 +148,7 @@ variable "log_include_cookies" {
 variable "log_prefix" {
   description = "An optional string that you want CloudFront to prefix to the access log filenames for this distribution"
   type        = string
+  default     = null
 }
 
 variable "aliases" {

--- a/modules/aws/EKS-Cluster/data.tf
+++ b/modules/aws/EKS-Cluster/data.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 data "aws_eks_cluster" "eks_cluster" {
-  name = aws_eks_cluster.eks_cluster.name
+  name     = join("-", [var.project, var.application, var.environment, var.region, "eks"])
 }
 # Obtain TLS certificate for the OIDC provider
 data "tls_certificate" "tls" {

--- a/modules/aws/EKS-Cluster/data.tf
+++ b/modules/aws/EKS-Cluster/data.tf
@@ -10,7 +10,7 @@
 # --------------------------------------------------------------------------------------
 
 data "aws_eks_cluster" "eks_cluster" {
-  name     = join("-", [var.project, var.application, var.environment, var.region, "eks"])
+  name = join("-", [var.project, var.application, var.environment, var.region, "eks"])
 }
 # Obtain TLS certificate for the OIDC provider
 data "tls_certificate" "tls" {

--- a/modules/aws/EKS-Cluster/data.tf
+++ b/modules/aws/EKS-Cluster/data.tf
@@ -8,9 +8,12 @@
 # You may not alter or remove any copyright or other notice from copies of this content.
 #
 # --------------------------------------------------------------------------------------
-
 data "aws_eks_cluster" "eks_cluster" {
-  name = join("-", [var.project, var.application, var.environment, var.region, "eks"])
+  name     = join("-", [var.project, var.application, var.environment, var.region, "eks"])
+
+  depends_on = [
+    aws_eks_cluster.eks_cluster
+  ]
 }
 # Obtain TLS certificate for the OIDC provider
 data "tls_certificate" "tls" {

--- a/modules/aws/EKS-Cluster/iam_role.tf
+++ b/modules/aws/EKS-Cluster/iam_role.tf
@@ -22,7 +22,7 @@ resource "aws_iam_role" "iam_role" {
       "Principal": {
         "Service": "eks.amazonaws.com"
       },
-      "Action": "sts:AssumeRole"
+      "Action": ["sts:AssumeRole", "sts:TagSession"]
     }
   ]
 }

--- a/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
+++ b/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
@@ -22,6 +22,8 @@ resource "aws_lb" "lb" {
 
   tags = var.tags
 
+  enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing
+
   dynamic "subnet_mapping" {
     for_each = var.subnet_ids
     content {

--- a/modules/aws/Elastic-LoadBalancer/variables.tf
+++ b/modules/aws/Elastic-LoadBalancer/variables.tf
@@ -64,3 +64,8 @@ variable "enable_shield_protection" {
   description = "Flag to indicate whether the ALB instance is protected by AWS Shield or not"
   default     = false
 }
+variable "enable_cross_zone_load_balancing" {
+  type        = string
+  description = "Flag to indicate whether the cross zone load balancing is enabled for the ALB instance or not"
+  default     = false
+}

--- a/modules/aws/Gateway/variables.tf
+++ b/modules/aws/Gateway/variables.tf
@@ -12,7 +12,7 @@
 variable "tags" {
   type        = map(string)
   description = "Default tags to be associated with the resource"
-  default = null
+  default     = null
 }
 variable "project" {
   type        = string

--- a/modules/aws/Gateway/variables.tf
+++ b/modules/aws/Gateway/variables.tf
@@ -12,6 +12,7 @@
 variable "tags" {
   type        = map(string)
   description = "Default tags to be associated with the resource"
+  default = null
 }
 variable "project" {
   type        = string

--- a/modules/aws/LoadBalancer-Target-Group/target_group.tf
+++ b/modules/aws/LoadBalancer-Target-Group/target_group.tf
@@ -10,12 +10,13 @@
 # --------------------------------------------------------------------------------------
 
 resource "aws_lb_target_group" "lb_target_group" {
-  name        = join("-", [var.project, var.application, var.environment, var.region, "lb-tg"])
-  target_type = var.target_type
-  port        = var.port
-  protocol    = var.protocol
-  vpc_id      = var.vpc_id
-  tags        = var.tags
+  name               = join("-", [var.project, var.application, var.environment, var.region, "lb-tg"])
+  target_type        = var.target_type
+  port               = var.port
+  protocol           = var.protocol
+  vpc_id             = var.vpc_id
+  preserve_client_ip = var.preserve_client_ip
+  tags               = var.tags
 }
 
 # Create target group attachments for each

--- a/modules/aws/LoadBalancer-Target-Group/variables.tf
+++ b/modules/aws/LoadBalancer-Target-Group/variables.tf
@@ -48,6 +48,12 @@ variable "target_group_attachments" {
     port              = optional(number)
   }))
   description = "List of target group attachments"
+  default     = {}
+}
+variable "preserve_client_ip" {
+  type        = bool
+  description = "Whether client IP preservation is enabled for the target group"
+  default     = null
 }
 variable "tags" {
   type        = map(string)

--- a/modules/aws/Metric-Alarm/metric_alarm.tf
+++ b/modules/aws/Metric-Alarm/metric_alarm.tf
@@ -30,13 +30,9 @@ resource "aws_cloudwatch_metric_alarm" "metric_alarm" {
 
   actions_enabled = var.enabled
 
+  datapoints_to_alarm = var.datapoints_to_alarm
+
   dimensions = var.dimensions
 
   tags = var.tags
-
-  lifecycle {
-    ignore_changes = [
-      datapoints_to_alarm
-    ]
-  }
 }

--- a/modules/aws/Metric-Alarm/variables.tf
+++ b/modules/aws/Metric-Alarm/variables.tf
@@ -98,6 +98,11 @@ variable "metric_usage_prefix" {
   type        = string
   description = "Prefix for the metric usage"
 }
+variable "datapoints_to_alarm" {
+  description = "The number of datapoints that must be breaching to trigger the alarm. Defaults to evaluation_periods."
+  type        = number
+  default     = null
+}
 variable "tags" {
   type        = map(string)
   description = "Tags to be attached to the resource"

--- a/modules/aws/RDS-Aurora/rds.tf
+++ b/modules/aws/RDS-Aurora/rds.tf
@@ -41,8 +41,8 @@ resource "aws_rds_cluster" "rds_cluster" {
 
   database_name               = var.database_name
   master_username             = var.master_username
-  master_password             = var.master_password
-  manage_master_user_password = var.manage_master_user_password
+  master_password             = var.manage_master_user_password ? null : var.master_password
+  manage_master_user_password = var.manage_master_user_password ? true : null
 
   db_cluster_parameter_group_name  = var.db_cluster_parameter_group_name
   db_instance_parameter_group_name = var.allow_major_version_upgrade == true ? var.db_instance_parameter_group_name : null
@@ -98,7 +98,7 @@ resource "aws_rds_cluster" "rds_cluster" {
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
   for_each           = var.cluster_instances
-  identifier         = "${local.cluster_name}-${each.value.name}"
+  identifier         = coalesce(each.value.instance_name_override, "${local.cluster_name}-${each.value.name}")
   cluster_identifier = aws_rds_cluster.rds_cluster.id
   instance_class     = var.db_cluster_instance_class == null ? each.value.instance_class : var.db_cluster_instance_class
   engine             = aws_rds_cluster.rds_cluster.engine

--- a/modules/aws/RDS-Aurora/variables.tf
+++ b/modules/aws/RDS-Aurora/variables.tf
@@ -215,6 +215,7 @@ variable "cluster_instances" {
   type = map(object({
     name                         = string
     custom_iam_instance_profile  = optional(string)
+    instance_name_override       = optional(string)
     db_parameter_group_name      = optional(string)
     instance_class               = optional(string)
     monitoring_interval          = optional(number, 0)

--- a/modules/aws/Secret-Manager-Secret/data.tf
+++ b/modules/aws/Secret-Manager-Secret/data.tf
@@ -25,6 +25,4 @@ data "aws_iam_policy_document" "iam_policy_document" {
     actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
     resources = [aws_secretsmanager_secret.secretsmanager_secret.arn]
   }
-
-  depends_on = [aws_secretsmanager_secret.secretsmanager_secret]
 }

--- a/modules/aws/VPC-Subnet/locals.tf
+++ b/modules/aws/VPC-Subnet/locals.tf
@@ -10,9 +10,21 @@
 # --------------------------------------------------------------------------------------
 
 locals {
-  name_prefix = var.availability_zone == null ? join("-", [var.project, var.application, var.environment, var.region]) : join("-", [var.project, var.application, var.environment, var.region, var.availability_zone])
-  rt_name     = join("-", [local.name_prefix, "snet-rt"])
-  subnet_name = join("-", [local.name_prefix, "snet"])
-  rt_tags     = merge(var.tags, { Name : local.rt_name })
-  subnet_tags = merge(var.tags, { Name : local.subnet_name })
+  # Normalise: treat empty list as a single "no-AZ" subnet using the base cidr_block as-is
+  azs      = length(var.availability_zone) > 0 ? var.availability_zone : [null]
+  az_count = length(local.azs)
+
+  # Number of extra bits to evenly subdivide the base CIDR across all AZs (0 when single)
+  newbits = local.az_count > 1 ? ceil(log(local.az_count, 2)) : 0
+
+  # Build the per-subnet map keyed by AZ name (or "default" when no AZ given)
+  subnet_map = {
+    for idx, az in local.azs :
+    (az != null ? az : "default") => {
+      az = az
+      # Use explicit override if provided, otherwise auto-subdivide from base cidr_block
+      cidr_block  = length(var.cidr_blocks) > 0 ? var.cidr_blocks[idx] : (local.az_count > 1 ? cidrsubnet(var.cidr_block, local.newbits, idx) : var.cidr_block)
+      name_prefix = az != null ? join("-", [var.project, var.application, var.environment, var.region, az]) : join("-", [var.project, var.application, var.environment, var.region])
+    }
+  }
 }

--- a/modules/aws/VPC-Subnet/locals.tf
+++ b/modules/aws/VPC-Subnet/locals.tf
@@ -10,9 +10,11 @@
 # --------------------------------------------------------------------------------------
 
 locals {
-  # Normalise: treat empty list as a single "no-AZ" subnet using the base cidr_block as-is
-  azs      = length(var.availability_zone) > 0 ? var.availability_zone : [null]
-  az_count = length(local.azs)
+  # Normalise: availability_zones (list) takes precedence over availability_zone (scalar).
+  # Treat empty/null as a single "no-AZ" subnet using the base cidr_block as-is.
+  _azs_resolved = length(var.availability_zones) > 0 ? var.availability_zones : (var.availability_zone != null ? [var.availability_zone] : [])
+  azs           = length(local._azs_resolved) > 0 ? local._azs_resolved : [null]
+  az_count      = length(local.azs)
 
   # Number of extra bits to evenly subdivide the base CIDR across all AZs (0 when single)
   newbits = local.az_count > 1 ? ceil(log(local.az_count, 2)) : 0
@@ -21,8 +23,7 @@ locals {
   subnet_map = {
     for idx, az in local.azs :
     (az != null ? az : "default") => {
-      az = az
-      # Use explicit override if provided, otherwise auto-subdivide from base cidr_block
+      az          = az
       cidr_block  = length(var.cidr_blocks) > 0 ? var.cidr_blocks[idx] : (local.az_count > 1 ? cidrsubnet(var.cidr_block, local.newbits, idx) : var.cidr_block)
       name_prefix = az != null ? join("-", [var.project, var.application, var.environment, var.region, az]) : join("-", [var.project, var.application, var.environment, var.region])
     }

--- a/modules/aws/VPC-Subnet/outputs.tf
+++ b/modules/aws/VPC-Subnet/outputs.tf
@@ -9,18 +9,35 @@
 #
 # --------------------------------------------------------------------------------------
 
+output "subnet_ids" {
+  value      = { for k, s in aws_subnet.subnet : k => s.id }
+  depends_on = [aws_subnet.subnet]
+}
+output "route_table_ids" {
+  value      = { for k, rt in aws_route_table.route_table : k => rt.id }
+  depends_on = [aws_route_table.route_table]
+}
+output "subnet_names" {
+  value = { for k, v in local.subnet_map : k => join("-", [v.name_prefix, "snet"]) }
+}
+output "subnet_cidr_blocks" {
+  value      = { for k, s in aws_subnet.subnet : k => s.cidr_block }
+  depends_on = [aws_subnet.subnet]
+}
+
+# Single-value aliases (first subnet) retained for backwards compatibility
 output "subnet_id" {
-  value      = aws_subnet.subnet.id
+  value      = values(aws_subnet.subnet)[0].id
   depends_on = [aws_subnet.subnet]
 }
 output "route_table_id" {
-  value      = aws_route_table.route_table.id
+  value      = values(aws_route_table.route_table)[0].id
   depends_on = [aws_route_table.route_table]
 }
 output "subnet_name" {
-  value = local.subnet_name
+  value = values(local.subnet_map)[0].name_prefix
 }
 output "subnet_cidr_block" {
-  value      = aws_subnet.subnet.cidr_block
+  value      = values(aws_subnet.subnet)[0].cidr_block
   depends_on = [aws_subnet.subnet]
 }

--- a/modules/aws/VPC-Subnet/subnet.tf
+++ b/modules/aws/VPC-Subnet/subnet.tf
@@ -19,6 +19,13 @@ resource "aws_subnet" "subnet" {
   map_public_ip_on_launch = var.auto_assign_public_ip
 
   tags = merge(var.tags, { Name = join("-", [each.value.name_prefix, "snet"]), availability_zone = each.value.az })
+
+  lifecycle {
+  precondition {
+    condition     = var.cidr_block != null || length(var.cidr_blocks) > 0
+    error_message = "At least one of cidr_block or cidr_blocks must be provided."
+  }
+}
 }
 
 resource "aws_route_table" "route_table" {

--- a/modules/aws/VPC-Subnet/subnet.tf
+++ b/modules/aws/VPC-Subnet/subnet.tf
@@ -10,18 +10,22 @@
 # --------------------------------------------------------------------------------------
 
 resource "aws_subnet" "subnet" {
+  for_each = local.subnet_map
+
   vpc_id                  = var.vpc_id
-  cidr_block              = var.cidr_block
+  cidr_block              = each.value.cidr_block
   enable_dns64            = var.enable_dns64
-  availability_zone       = var.availability_zone
+  availability_zone       = each.value.az
   map_public_ip_on_launch = var.auto_assign_public_ip
 
-  tags = local.subnet_tags
+  tags = merge(var.tags, { Name = join("-", [each.value.name_prefix, "snet"]), availability_zone = each.value.az })
 }
 
 resource "aws_route_table" "route_table" {
+  for_each = local.subnet_map
+
   vpc_id = var.vpc_id
-  tags   = local.rt_tags
+  tags   = merge(var.tags, { Name = join("-", [each.value.name_prefix, "snet-rt"]), availability_zone = each.value.az })
 
   dynamic "route" {
     for_each = var.custom_routes
@@ -42,8 +46,10 @@ resource "aws_route_table" "route_table" {
 }
 
 resource "aws_route_table_association" "route_table_association" {
-  subnet_id      = aws_subnet.subnet.id
-  route_table_id = aws_route_table.route_table.id
+  for_each = local.subnet_map
+
+  subnet_id      = aws_subnet.subnet[each.key].id
+  route_table_id = aws_route_table.route_table[each.key].id
 
   depends_on = [
     aws_subnet.subnet,

--- a/modules/aws/VPC-Subnet/variables.tf
+++ b/modules/aws/VPC-Subnet/variables.tf
@@ -36,7 +36,12 @@ variable "enable_dns64" {
 }
 variable "cidr_block" {
   type        = string
-  description = "CIDR block for the subnet"
+  description = "Base CIDR block. Automatically sub-divided across availability_zones when multiple are provided."
+}
+variable "cidr_blocks" {
+  type        = list(string)
+  description = "Optional explicit CIDR blocks per availability zone. When provided, overrides automatic cidr_block subdivision. Must match the length of availability_zone."
+  default     = []
 }
 variable "tags" {
   type        = map(string)
@@ -44,9 +49,9 @@ variable "tags" {
   default     = {}
 }
 variable "availability_zone" {
-  type        = string
-  description = "Availability zones for the Subnet"
-  default     = null
+  type        = list(string)
+  description = "Availability zones for the Subnets. Provide multiple values to create one subnet per AZ."
+  default     = []
 }
 variable "auto_assign_public_ip" {
   type        = bool

--- a/modules/aws/VPC-Subnet/variables.tf
+++ b/modules/aws/VPC-Subnet/variables.tf
@@ -38,11 +38,21 @@ variable "cidr_block" {
   type        = string
   description = "Base CIDR block. Automatically sub-divided across availability_zones when multiple are provided."
   default     = null
+
+  validation {
+    condition     = var.cidr_block == null || can(cidrnetmask(var.cidr_block))
+    error_message = "cidr_block must be a valid CIDR notation (e.g. 10.0.0.0/24)."
+  }
 }
 variable "cidr_blocks" {
   type        = list(string)
   description = "Optional explicit CIDR blocks per availability zone. When provided, overrides automatic cidr_block subdivision. Must match the length of availability_zone."
   default     = []
+
+  validation {
+    condition     = alltrue([for cidr in var.cidr_blocks : can(cidrnetmask(cidr))])
+    error_message = "All entries in cidr_blocks must be valid CIDR notation (e.g. 10.0.0.0/24)."
+  }
 }
 variable "tags" {
   type        = map(string)

--- a/modules/aws/VPC-Subnet/variables.tf
+++ b/modules/aws/VPC-Subnet/variables.tf
@@ -37,6 +37,7 @@ variable "enable_dns64" {
 variable "cidr_block" {
   type        = string
   description = "Base CIDR block. Automatically sub-divided across availability_zones when multiple are provided."
+  default     = null
 }
 variable "cidr_blocks" {
   type        = list(string)

--- a/modules/aws/VPC-Subnet/variables.tf
+++ b/modules/aws/VPC-Subnet/variables.tf
@@ -60,8 +60,13 @@ variable "tags" {
   default     = {}
 }
 variable "availability_zone" {
+  type        = string
+  description = "Availability zone for a single subnet. Deprecated: use availability_zones (list) instead."
+  default     = null
+}
+variable "availability_zones" {
   type        = list(string)
-  description = "Availability zones for the Subnets. Provide multiple values to create one subnet per AZ."
+  description = "Availability zones for the Subnets. Provide multiple values to create one subnet per AZ. Takes precedence over availability_zone when provided."
   default     = []
 }
 variable "auto_assign_public_ip" {


### PR DESCRIPTION
## Purpose
This pull request introduces several enhancements and configuration options to the AWS infrastructure Terraform modules. The most significant changes add support for Origin Shield and custom SSL certificates in CloudFront distributions, enable cross-zone load balancing for Elastic Load Balancers, and improve IAM role permissions and CloudWatch alarm configurability.

**CloudFront Distribution Enhancements:**

* Added support for Origin Shield configuration by introducing `origin_shield` block and related variables (`origin_shield_enabled`, `origin_shield_region`). [[1]](diffhunk://#diff-c0d9452b6e4161627ffa7dad16317ce8ccc5635ea0e410512c75b831b51b8335R32-R36) [[2]](diffhunk://#diff-7a26d8c75ff2b472e7b006d63a85a19cfa5bb20f63eee53960888d186542f3aaR151-R203)
* Enabled use of custom ACM certificates and SSL configuration by updating the `viewer_certificate` block and adding variables for certificate ARN, SSL support method, and minimum protocol version. [[1]](diffhunk://#diff-c0d9452b6e4161627ffa7dad16317ce8ccc5635ea0e410512c75b831b51b8335L87-R97) [[2]](diffhunk://#diff-7a26d8c75ff2b472e7b006d63a85a19cfa5bb20f63eee53960888d186542f3aaR151-R203)
* Added variables and configuration for cache policy and response headers policy in the `default_cache_behavior` block. [[1]](diffhunk://#diff-c0d9452b6e4161627ffa7dad16317ce8ccc5635ea0e410512c75b831b51b8335R50-R51) [[2]](diffhunk://#diff-7a26d8c75ff2b472e7b006d63a85a19cfa5bb20f63eee53960888d186542f3aaR151-R203)

**Elastic Load Balancer Improvements:**

* Enabled cross-zone load balancing by setting `enable_cross_zone_load_balancing` to `true` in the load balancer resource.

**IAM Role Permissions:**

* Updated IAM role policy to allow both `sts:AssumeRole` and `sts:TagSession` actions for EKS, improving session tagging capabilities.

**Load Balancer Target Group Enhancements:**

* Added support for client IP preservation in target groups by introducing the `preserve_client_ip` variable. [[1]](diffhunk://#diff-56ce23ee26d46cc3d247180ebe09baf1ca8685cae17b6a38ab72b30af76b84a1R18) [[2]](diffhunk://#diff-3473b55bd7f7e5b7059a486cec0257c2371ca76ee75bb96e6533de455f46929dR51-R56)

**CloudWatch Metric Alarm Configuration:**

* Added the `datapoints_to_alarm` variable and resource property to allow more granular alarm triggering, and removed lifecycle ignore changes for this property. [[1]](diffhunk://#diff-35d4eee068f2f4b78a3919861cadb44e2f3094c3ef67921ad72f00b494beabe9R33-L41) [[2]](diffhunk://#diff-a0644503e21d9d922bf4767581d0b9fddf06dd051bfa3050ad4d559815a1a0f6R101-R105)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CloudFront: Origin Shield, aliases, conditional logging, configurable cache & response‑headers policies, and custom SSL/certificate options.
  * Load Balancer: cross‑zone load balancing toggle and client IP preservation.
  * VPC/Subnets: multi‑AZ subnet provisioning with per‑subnet outputs (IDs, names, CIDRs).
  * RDS Aurora: optional per‑instance name override.
  * Metric Alarms: configurable datapoints‑to‑alarm threshold.
  * EKS IAM: session tagging enabled.
* **Chore**
  * Backup resource names now use underscores instead of dashes; several tag variables defaulted to null.
* **Style/Behavior**
  * Removed an explicit data dependency in Secret Manager data source (evaluation order adjusted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->