### PR TITLE
Add service_id to Metric-Alarm-Group for Smart Incident routing

### DIFF
--- a/modules/aws/Metric-Alarm-Group/metric-alarm-group.tf
+++ b/modules/aws/Metric-Alarm-Group/metric-alarm-group.tf
@@ -36,6 +36,7 @@ module "warning-metric-alarm" {
     service     = var.product
     severity    = title(each.value.priority)
     environment = var.environment
+    service_id  = var.service_id
   })
   metric_usage_prefix = lower(join("-", [var.project, var.application, var.region, var.environment, var.resource_infix, each.value.statistic, each.value.metric_name, each.value.priority]))
 

--- a/modules/aws/Metric-Alarm-Group/variables.tf
+++ b/modules/aws/Metric-Alarm-Group/variables.tf
@@ -99,3 +99,8 @@ variable "product" {
   description = "Product name used in alarm descriptions"
   default     = "Choreo"
 }
+variable "service_id" {
+  type        = string
+  description = "Service ID for Smart Incident routing"
+  default     = null
+}


### PR DESCRIPTION
Adds an optional `service_id` variable to the `Metric-Alarm-Group` module. When set, the value is included in the `alarm_description` JSON payload, enabling ServiceNow Smart Incident to route and classify alarms by service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional service identifier support for monitoring alarms to improve Smart Incident routing and organization; when provided, the identifier is included in alarm descriptions to aid incident detection and grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->