### PR TITLE
Add option to customize log_group_name_prefix in Network-Firewall module

### DIFF
--- a/modules/aws/Network-Firewall/network_firewall.tf
+++ b/modules/aws/Network-Firewall/network_firewall.tf
@@ -59,7 +59,7 @@ resource "aws_networkfirewall_firewall_policy" "networkfirewall_firewall_policy"
 
 resource "aws_cloudwatch_log_group" "nfw_cloudwatch_log_group" {
   for_each = try(var.logging_config, {})
-  name     = "/aws/network-firewall/${each.key}"
+  name     = "${var.log_group_name_prefix}/${each.key}"
 
   tags = merge(var.tags)
 

--- a/modules/aws/Network-Firewall/variables.tf
+++ b/modules/aws/Network-Firewall/variables.tf
@@ -104,3 +104,10 @@ variable "aws_managed_rule_group" {
   type        = list(any)
   default     = []
 }
+
+variable "log_group_name_prefix" {
+  description = "Prefix for the CloudWatch log group names created for Network Firewall logging. Defaults to '/aws/network-firewall'. Override this when deploying multiple firewalls in the same account and region to avoid name collisions."
+  type        = string
+  default     = "/aws/network-firewall"
+}
+


### PR DESCRIPTION
## Purpose

$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CloudWatch log group names for AWS Network Firewall logging are now customizable via a configurable prefix parameter, with a default value maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->