### PR TITLE
Add custom ami terraform module and lambda environment variable support

### DIFF
--- a/modules/aws/Custom-AMI/custom_ami.tf
+++ b/modules/aws/Custom-AMI/custom_ami.tf
@@ -1,19 +1,28 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 
-resource "aws_ami" "custom_ami" {
-  name                = var.custom_ami_name
-  description         = var.custom_ami_description
-  architecture        = var.custom_ami_architecture
-  virtualization_type = var.custom_ami_virtualization_type
-  imds_support        = var.custom_ami_imds_support
-  tags                = var.custom_ami_tags
+resource "aws_ami" "ami" {
+  name                = var.ami_name
+  description         = var.ami_description
+  architecture        = var.ami_architecture
+  virtualization_type = var.ami_virtualization_type
+  imds_support        = var.ami_imds_support
+  tags                = var.ami_tags
 }

--- a/modules/aws/Custom-AMI/custom_ami.tf
+++ b/modules/aws/Custom-AMI/custom_ami.tf
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+resource "aws_ami" "custom_ami" {
+  name                = var.custom_ami_name
+  description         = var.custom_ami_description
+  architecture        = var.custom_ami_architecture
+  virtualization_type = var.custom_ami_virtualization_type
+  imds_support        = var.custom_ami_imds_support
+  tags                = var.custom_ami_tags
+}

--- a/modules/aws/Custom-AMI/outputs.tf
+++ b/modules/aws/Custom-AMI/outputs.tf
@@ -1,20 +1,29 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 
 output "id" {
   description = "The ID of the created AMI"
-  value       = aws_ami.custom_ami.id
+  value       = aws_ami.ami.id
 }
 
 output "arn" {
   description = "The ARN of the created AMI"
-  value       = aws_ami.custom_ami.arn
+  value       = aws_ami.ami.arn
 }

--- a/modules/aws/Custom-AMI/outputs.tf
+++ b/modules/aws/Custom-AMI/outputs.tf
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  description = "The ID of the created AMI"
+  value       = aws_ami.custom_ami.id
+}
+
+output "arn" {
+  description = "The ARN of the created AMI"
+  value       = aws_ami.custom_ami.arn
+}

--- a/modules/aws/Custom-AMI/variables.tf
+++ b/modules/aws/Custom-AMI/variables.tf
@@ -50,4 +50,5 @@ variable "ami_imds_support" {
 variable "ami_tags" {
   description = "A map of tags to assign to the resource."
   type        = map(string)
+  default     = {}
 }

--- a/modules/aws/Custom-AMI/variables.tf
+++ b/modules/aws/Custom-AMI/variables.tf
@@ -1,44 +1,53 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 
-variable "custom_ami_name" {
+variable "ami_name" {
   description = "A region-unique name for the AMI."
   type        = string
 }
 
-variable "custom_ami_description" {
+variable "ami_description" {
   description = "A longer, human-readable description for the AMI."
   type        = string
   default     = null
 }
 
-variable "custom_ami_architecture" {
+variable "ami_architecture" {
   description = "Machine architecture for created instances. Defaults to arm64."
   type        = string
   default     = "arm64"
 }
 
-variable "custom_ami_virtualization_type" {
+variable "ami_virtualization_type" {
   description = "Keyword to choose what virtualization mode created instances will use."
   type        = string
   default     = "hvm"
 }
 
-variable "custom_ami_imds_support" {
+variable "ami_imds_support" {
   description = "If v2.0 is selected, EC2 instances will only support IMDSv2."
   type        = string
   default     = "v2.0"
 }
 
-variable "custom_ami_tags" {
+variable "ami_tags" {
   description = "A map of tags to assign to the resource."
   type        = map(string)
 }

--- a/modules/aws/Custom-AMI/variables.tf
+++ b/modules/aws/Custom-AMI/variables.tf
@@ -1,0 +1,44 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+variable "custom_ami_name" {
+  description = "A region-unique name for the AMI."
+  type        = string
+}
+
+variable "custom_ami_description" {
+  description = "A longer, human-readable description for the AMI."
+  type        = string
+  default     = null
+}
+
+variable "custom_ami_architecture" {
+  description = "Machine architecture for created instances. Defaults to arm64."
+  type        = string
+  default     = "arm64"
+}
+
+variable "custom_ami_virtualization_type" {
+  description = "Keyword to choose what virtualization mode created instances will use."
+  type        = string
+  default     = "hvm"
+}
+
+variable "custom_ami_imds_support" {
+  description = "If v2.0 is selected, EC2 instances will only support IMDSv2."
+  type        = string
+  default     = "v2.0"
+}
+
+variable "custom_ami_tags" {
+  description = "A map of tags to assign to the resource."
+  type        = map(string)
+}

--- a/modules/aws/Custom-AMI/versions.tf
+++ b/modules/aws/Custom-AMI/versions.tf
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}

--- a/modules/aws/Custom-AMI/versions.tf
+++ b/modules/aws/Custom-AMI/versions.tf
@@ -1,11 +1,20 @@
 # -------------------------------------------------------------------------------------
 #
-# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
-# This software is the property of WSO2 LLC. and its suppliers, if any.
-# Dissemination of any information or reproduction of any material contained
-# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
-# You may not alter or remove any copyright or other notice from copies of this content.
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 # --------------------------------------------------------------------------------------
 

--- a/modules/aws/Lambda-Function/lambda_function.tf
+++ b/modules/aws/Lambda-Function/lambda_function.tf
@@ -36,6 +36,13 @@ resource "aws_lambda_function" "lambda_function" {
   source_code_hash = data.archive_file.archive_lambda_function.output_base64sha256
   runtime          = var.runtime_version
   tags             = var.tags
+
+  dynamic "environment" {
+    for_each = length(var.environment_variables) > 0 ? [1] : []
+    content {
+      variables = var.environment_variables
+    }
+  }
 }
 
 # Ignore: AVD-AWS-0017 (https://avd.aquasec.com/misconfig/aws/ec2/avd-aws-0017)

--- a/modules/aws/Lambda-Function/variables.tf
+++ b/modules/aws/Lambda-Function/variables.tf
@@ -73,4 +73,5 @@ variable "environment_variables" {
   type        = map(string)
   description = "Environment variables to set on the Lambda function"
   default     = {}
+  nullable    = false
 }

--- a/modules/aws/Lambda-Function/variables.tf
+++ b/modules/aws/Lambda-Function/variables.tf
@@ -73,5 +73,4 @@ variable "environment_variables" {
   type        = map(string)
   description = "Environment variables to set on the Lambda function"
   default     = {}
-  nullable    = false
 }

--- a/modules/aws/Lambda-Function/variables.tf
+++ b/modules/aws/Lambda-Function/variables.tf
@@ -68,3 +68,9 @@ variable "cloudwatch_log_group_kms_key_id" {
   type        = string
   default     = null
 }
+
+variable "environment_variables" {
+  type        = map(string)
+  description = "Environment variables to set on the Lambda function"
+  default     = {}
+}


### PR DESCRIPTION
## Purpose

This pull request introduces a new Terraform module for creating custom AWS AMIs and adds support for environment variables in the Lambda Function module. The main highlights are the addition of a reusable, configurable custom AMI module, and enhanced flexibility for Lambda deployments by allowing environment variables.

**Custom AMI module additions:**

* Added a new `Custom-AMI` module, including:
  - Resource definition for `aws_ami` with configurable name, description, architecture, virtualization type, IMDS support, and tags (`custom_ami.tf`)
  - Input variables for all AMI parameters, with sensible defaults and descriptions (`variables.tf`)
  - Outputs for the created AMI's ID and ARN (`outputs.tf`)
  - Version constraints for Terraform and AWS provider (`versions.tf`)

**Lambda Function enhancements:**

* Added support for setting environment variables on Lambda functions via a new `environment_variables` input variable and dynamic block in the resource definition (`lambda_function.tf`, `variables.tf`)