### PR TITLE
Enable CloudFront module logging by default

### DIFF
--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -129,5 +129,9 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
       condition     = var.cloudfront_default_certificate == true ? var.cloudfront_acm_certificate_arn == null : true
       error_message = "cloudfront_acm_certificate_arn must not be set when cloudfront_default_certificate is true."
     }
+    precondition {
+      condition     = var.enable_logging_config ? var.log_bucket_name != null : true
+      error_message = "log_bucket_name must be provided when enable_logging_config is true."
+    }
   }
 }

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
   aliases = var.aliases
 
   dynamic "logging_config" {
-    for_each = var.log_bucket_name != null ? [1] : []
+    for_each = var.enable_logging_config ? [1] : []
     content {
       bucket          = var.log_bucket_name
       include_cookies = var.log_include_cookies

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -134,10 +134,16 @@ variable "ordered_cache_behaviors" {
   default = []
 }
 
+variable "enable_logging_config" {
+  description = "Whether to enable logging configuration for the CloudFront distribution"
+  type        = bool
+  default     = true
+}
+
 variable "log_bucket_name" {
   description = "The S3 bucket name for CloudFront access logs (e.g., mybucket.s3.amazonaws.com)"
   type        = string
-  default     = null
+  default     = "cloudfront-log-bucket"
 }
 
 variable "log_include_cookies" {

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -141,9 +141,14 @@ variable "enable_logging_config" {
 }
 
 variable "log_bucket_name" {
-  description = "The S3 bucket name for CloudFront access logs (e.g., mybucket.s3.amazonaws.com)"
+  description = "The S3 bucket domain for CloudFront access logs. Must be in the form '<bucket-name>.s3.amazonaws.com'"
   type        = string
-  default     = "cloudfront-log-bucket"
+  default     = null
+
+  validation {
+    condition     = var.log_bucket_name == null || can(regex("^[a-z0-9][a-z0-9.-]*\\.s3\\.amazonaws\\.com$", var.log_bucket_name))
+    error_message = "log_bucket_name must be in the form '<bucket-name>.s3.amazonaws.com' (e.g., mybucket.s3.amazonaws.com)."
+  }
 }
 
 variable "log_include_cookies" {


### PR DESCRIPTION
## Purpose
This pull request updates the CloudFront Terraform module to improve the handling and configuration of logging. The main change is the introduction of a new variable to explicitly control whether logging is enabled, as well as a default value for the log bucket name.

**Logging configuration improvements:**

* Added a new variable `enable_logging_config` (default: `true`) to allow users to explicitly enable or disable logging for the CloudFront distribution.
* Updated the dynamic `logging_config` block in `cloudfront.tf` to use `enable_logging_config` instead of checking if `log_bucket_name` is not null. This makes the logging behavior more predictable and user-controlled.
* Set a default value for `log_bucket_name` (`"cloudfront-log-bucket"`) to avoid the need for users to always specify a bucket name.