### PR TITLE
Add AWS CloudWatch Metric Alarm custom payload fields required for Smart Incident Handler compatibility 

### DIFF
--- a/modules/aws/Metric-Alarm-Group/metric-alarm-group.tf
+++ b/modules/aws/Metric-Alarm-Group/metric-alarm-group.tf
@@ -32,10 +32,12 @@ module "warning-metric-alarm" {
   insufficient_data_actions = var.insufficient_data_actions
 
   alarm_description = jsonencode({
-    category    = "service_interruption"
-    service     = var.product
-    severity    = title(each.value.priority)
-    environment = var.environment
+    category      = "service_interruption"
+    service       = var.product
+    severity      = title(each.value.priority)
+    environment   = var.environment
+    service_id    = var.service_id
+    deployment_id = var.deployment_id
   })
   metric_usage_prefix = lower(join("-", [var.project, var.application, var.region, var.environment, var.resource_infix, each.value.statistic, each.value.metric_name, each.value.priority]))
 

--- a/modules/aws/Metric-Alarm-Group/variables.tf
+++ b/modules/aws/Metric-Alarm-Group/variables.tf
@@ -99,3 +99,14 @@ variable "product" {
   description = "Product name used in alarm descriptions"
   default     = "Choreo"
 }
+# Smart incident handler compatibility
+variable "service_id" {
+  type        = string
+  description = "Service ID for Smart Incident routing"
+  default     = null
+}
+variable "deployment_id" {
+  type        = string
+  description = "Deployment ID for Smart Incident creator processing"
+  default     = null
+}


### PR DESCRIPTION
## Purpose
$subject on behalf of https://github.com/wso2-enterprise/choreo/issues/39406

Includes changes from the original PR: https://github.com/wso2/aws-terraform-modules/pull/173

## Goals
https://github.com/wso2-enterprise/choreo/issues/39406

## Approach
Update relevant Terraform module for CloudWatch Metric Alarms with the custom fields