### PR TITLE
Order fivetuple stateful rule groups after aws_managed to preserve pass-all catch-all semantics

### DIFF
--- a/modules/aws/Network-Firewall/locals.tf
+++ b/modules/aws/Network-Firewall/locals.tf
@@ -10,6 +10,20 @@
 # --------------------------------------------------------------------------------------
 
 locals {
-  this_stateful_group_arn  = concat(aws_networkfirewall_rule_group.suricata_stateful_group[*].arn, aws_networkfirewall_rule_group.domain_stateful_group[*].arn, aws_networkfirewall_rule_group.fivetuple_stateful_group[*].arn)
+  # Custom stateful rule groups evaluated BEFORE AWS-managed groups.
+  # Suricata and domain rule groups typically encode specific block/pass rules
+  # that should take precedence over generic AWS-managed signature drops.
+  this_stateful_group_arn = concat(
+    aws_networkfirewall_rule_group.suricata_stateful_group[*].arn,
+    aws_networkfirewall_rule_group.domain_stateful_group[*].arn,
+  )
+
+  # 5-tuple stateful rule groups evaluated AFTER AWS-managed groups.
+  # Reserved for pass-all catch-alls — the pattern that lets a policy run
+  # with stateful_default_actions = ["aws:drop_strict"] while still allowing
+  # traffic that no drop rule matched (typical use: eliminate alert_strict
+  # log noise while preserving a nominal default-deny posture).
+  this_stateful_group_arn_catchall = aws_networkfirewall_rule_group.fivetuple_stateful_group[*].arn
+
   this_stateless_group_arn = concat(aws_networkfirewall_rule_group.stateless_group[*].arn)
 }

--- a/modules/aws/Network-Firewall/network_firewall.tf
+++ b/modules/aws/Network-Firewall/network_firewall.tf
@@ -54,19 +54,19 @@ resource "aws_networkfirewall_firewall_policy" "networkfirewall_firewall_policy"
       }
     }
 
-    #StateFul Rule Group Reference
+    # Custom Suricata + domain rule groups — priority 1..N, evaluated FIRST.
+    # Lower number = evaluated first in strict order.
     dynamic "stateful_rule_group_reference" {
       for_each = local.this_stateful_group_arn
       content {
-        # Priority is sequentially as per index in stateful_group_arn list.
-        # Lower number = evaluated first. Suricata (blocklist) groups come before
-        # fivetuple (pass-all) groups in the concat order defined in locals.tf.
         priority     = var.enable_strict_order ? index(local.this_stateful_group_arn, stateful_rule_group_reference.value) + 1 : null
         resource_arn = stateful_rule_group_reference.value
       }
     }
 
-    # AWS Managed Rule Group References (with optional DROP_TO_ALERT override for logging only mode)
+    # AWS Managed Rule Groups — priority N+1..N+M, evaluated after custom
+    # Suricata/domain groups but BEFORE the fivetuple catch-all. Optional
+    # DROP_TO_ALERT override for logging-only mode.
     dynamic "stateful_rule_group_reference" {
       for_each = var.aws_managed_rule_group
       content {
@@ -78,6 +78,19 @@ resource "aws_networkfirewall_firewall_policy" "networkfirewall_firewall_policy"
             action = stateful_rule_group_reference.value.override_action
           }
         }
+      }
+    }
+
+    # 5-tuple catch-all rule groups — priority N+M+1..N+M+K, evaluated LAST.
+    # This is where pass-all catch-alls belong: they only match traffic that
+    # none of the custom or AWS-managed drop groups above claimed. Keeps the
+    # enforced tier effective while still allowing default-deny + drop_strict
+    # to be set as stateful_default_actions without dropping legitimate traffic.
+    dynamic "stateful_rule_group_reference" {
+      for_each = local.this_stateful_group_arn_catchall
+      content {
+        priority     = var.enable_strict_order ? length(local.this_stateful_group_arn) + length(var.aws_managed_rule_group) + index(local.this_stateful_group_arn_catchall, stateful_rule_group_reference.value) + 1 : null
+        resource_arn = stateful_rule_group_reference.value
       }
     }
   }


### PR DESCRIPTION
### Problem
  When `enable_strict_order = true` and a caller sets both `fivetuple_stateful_rule_group` (with pass-all rules) and `aws_managed_rule_group` (with drop groups like `MalwareDomainsStrictOrder`), the fivetuple pass-all is assigned a lower priority number than the AWS-managed groups. In strict order the first match wins, so pass-all matches every packet before any AWS-managed drop rule can fire — silently disabling threat protection.
  
  ### Fix
  Split `this_stateful_group_arn` into two tiers so fivetuple groups get priorities *after* `aws_managed_rule_group`. Suricata and domain groups (which typically encode specific rules) continue to evaluate first; fivetuple (documented as the pass-all catch-all layer) now correctly evaluates last. 
  
  ### Compatibility
  - Callers using only `suricata_stateful_rule_group` and/or `domain_stateful_rule_group`: unchanged.
  - Callers using only `fivetuple_stateful_rule_group` (no `aws_managed_rule_group`): unchanged.
  - Callers using `fivetuple_stateful_rule_group` **with** `aws_managed_rule_group`: previously produced an unsafe configuration where AWS-managed drops never fired. Now behaves correctly.
  
  Not a breaking change: the previous combination has no safe working use case.