### PR TITLE
[Main] Fix Elastic-LoadBalancer crash when internal LB omits private_ip_addresses

### DIFF
--- a/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
+++ b/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
@@ -29,7 +29,7 @@ resource "aws_lb" "lb" {
     content {
       subnet_id            = subnet_mapping.value
       allocation_id        = var.internal_usage_flag == false ? aws_eip.eip[subnet_mapping.key].id : null
-      private_ipv4_address = var.internal_usage_flag == true ? var.private_ip_addresses[subnet_mapping.key] : null
+      private_ipv4_address = var.internal_usage_flag ? lookup(var.private_ip_addresses, subnet_mapping.key, null) : null
     }
   }
 }


### PR DESCRIPTION
## Purpose

Since v1.57.2 the internal branch of subnet_mapping dereferenced
var.private_ip_addresses[subnet_mapping.key] directly. Callers that
want AWS to auto-assign the NLB private IP (i.e. no private_ip_addresses
passed) hit "Invalid index" on an empty map for every subnet.

Use lookup(..., null) so an omitted or partial private_ip_addresses map
falls through to AWS-assigned addressing, while callers that do supply
IPs continue to get them.