### PR TITLE
fix(Transit-Gateway-Peering): reference created attachment by id instead of ambiguous lookup

### DIFF
--- a/modules/aws/Transit-Gateway-Peering/outputs.tf
+++ b/modules/aws/Transit-Gateway-Peering/outputs.tf
@@ -2,5 +2,6 @@ output "local_transit_gateway_attachment_id" {
   value = aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id
 }
 output "peer_transit_gateway_attachment_id" {
-  value = data.aws_ec2_transit_gateway_peering_attachment.peer_transit_gateway_peering_attachment.id
+  # Same attachment (one id shared by both TGWs); use the created resource, not a lookup.
+  value = aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id
 }

--- a/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
+++ b/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
@@ -16,18 +16,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "transit_gateway_peering_a
   transit_gateway_id      = var.local_transit_gateway_id
   tags                    = var.default_tags
 }
-data "aws_ec2_transit_gateway_peering_attachment" "peer_transit_gateway_peering_attachment" {
-  filter {
-    name   = "transit-gateway-id"
-    values = [var.peer_transit_gateway_id]
-  }
-  filter {
-    name   = "state"
-    values = ["available", "pendingAcceptance", "pending"]
-  }
-
-  depends_on = [aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment]
-}
 resource "aws_ec2_transit_gateway_peering_attachment_accepter" "transit_gateway_peering_attachment_accepter" {
-  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.peer_transit_gateway_peering_attachment.id
+  # Use the created attachment's id directly; a data-source lookup matches every peering on the TGW.
+  transit_gateway_attachment_id = aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id
 }


### PR DESCRIPTION
## Description:
The module created the peering attachment but then re-discovered it via a data source
filtered only by transit-gateway-id. That filter matches every peering on the TGW, so once
a second peering exists (hit while adding a cross-region DR peering to a hub TGW that already
had an intra-region peering), the lookup returned multiple results and terraform failed with
"multiple EC2 Transit Gateway Peering Attachments matched".

## Change: 
The accepter and the peer_transit_gateway_attachment_id output now use the created
resource's own id (aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id),
and the data source is removed.

## Impact: 
A peering attachment has a single id shared by both TGWs, so this is a no-op for
existing single-peering setups (same id, clean plan) and stays correct for any number of
peerings on the TGW.

## Related Issue
- https://github.com/wso2-enterprise/wso2cloud/issues/762