### PR TITLE
fix(Transit-Gateway-Peering): narrow attachment lookup by attachment-id to fix "multiple matched"

### DIFF
--- a/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
+++ b/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
@@ -16,7 +16,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "transit_gateway_peering_a
   transit_gateway_id      = var.local_transit_gateway_id
   tags                    = var.default_tags
 }
-# Look up this module's own attachment by its id, so the lookup stays unique even when the TGW hasbmore than one peering.
+# Look up this module's own attachment by its id, so the lookup stays unique even when the TGW has more than one peering.
 data "aws_ec2_transit_gateway_peering_attachment" "peer_transit_gateway_peering_attachment" {
   filter {
     name   = "transit-gateway-id"

--- a/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
+++ b/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
@@ -16,7 +16,20 @@ resource "aws_ec2_transit_gateway_peering_attachment" "transit_gateway_peering_a
   transit_gateway_id      = var.local_transit_gateway_id
   tags                    = var.default_tags
 }
+# Look up this module's own attachment by its id, so the lookup stays unique even when the TGW hasbmore than one peering.
+data "aws_ec2_transit_gateway_peering_attachment" "peer_transit_gateway_peering_attachment" {
+  filter {
+    name   = "transit-gateway-id"
+    values = [var.peer_transit_gateway_id]
+  }
+  filter {
+    name   = "transit-gateway-attachment-id"
+    values = [aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id]
+  }
+  depends_on = [aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment]
+}
+
+# Accept from the peer side via the data source (accepting via the resource id is rejected by AWS).
 resource "aws_ec2_transit_gateway_peering_attachment_accepter" "transit_gateway_peering_attachment_accepter" {
-  # Use the created attachment's id directly; a data-source lookup matches every peering on the TGW.
-  transit_gateway_attachment_id = aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id
+  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.peer_transit_gateway_peering_attachment.id
 }


### PR DESCRIPTION
## Problem
The module's data source that resolves the peering attachment filtered only by
`transit-gateway-id`, which matches EVERY peering attachment on that TGW. As soon as a
second peering exists on the same TGW (e.g. a cross-region DR peering added alongside the
existing hub-to-hub one), the lookup returns multiple results and terraform fails with:

  Error: multiple EC2 Transit Gateway Peering Attachments matched; use additional
  constraints to reduce matches to a single EC2 Transit Gateway Peering Attachment

## Fix
Add a second filter on `transit-gateway-attachment-id` set to the id of the attachment this
module created. The lookup now resolves to exactly this module's own peering, regardless of
how many peerings the TGW has.

The data-source lookup is kept (the accepter accepts via it). Accepting via the created
resource's id directly was tried and rejected by AWS ("Cannot accept … as the source of the
peering request"), so the create → lookup → accept flow is preserved.

##Related Issue
- https://github.com/wso2-enterprise/wso2cloud/issues/762
- https://github.com/wso2-enterprise/wso2-paas/issues/31