### PR TITLE
[MAIN] fix(tgw-peering): look up attachment by id only so pending same-region

### DIFF
--- a/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
+++ b/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
@@ -16,10 +16,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "transit_gateway_peering_a
   transit_gateway_id      = var.local_transit_gateway_id
   tags                    = var.default_tags
 }
-# Look up this module's own attachment by its attachment id alone. The id is unique, so the
-# lookup stays unambiguous even when the TGW has more than one peering. Filtering on the peer
-# transit-gateway-id (as before) hid same-region peerings while pendingAcceptance, which blocked
-# the accepter from ever running; keying only on the attachment id finds it in every state.
+# Look up the attachment by its id alone; the id is unique and resolves in every state.
 data "aws_ec2_transit_gateway_peering_attachment" "peer_transit_gateway_peering_attachment" {
   filter {
     name   = "transit-gateway-attachment-id"

--- a/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
+++ b/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
@@ -16,12 +16,11 @@ resource "aws_ec2_transit_gateway_peering_attachment" "transit_gateway_peering_a
   transit_gateway_id      = var.local_transit_gateway_id
   tags                    = var.default_tags
 }
-# Look up this module's own attachment by its id, so the lookup stays unique even when the TGW has more than one peering.
+# Look up this module's own attachment by its attachment id alone. The id is unique, so the
+# lookup stays unambiguous even when the TGW has more than one peering. Filtering on the peer
+# transit-gateway-id (as before) hid same-region peerings while pendingAcceptance, which blocked
+# the accepter from ever running; keying only on the attachment id finds it in every state.
 data "aws_ec2_transit_gateway_peering_attachment" "peer_transit_gateway_peering_attachment" {
-  filter {
-    name   = "transit-gateway-id"
-    values = [var.peer_transit_gateway_id]
-  }
   filter {
     name   = "transit-gateway-attachment-id"
     values = [aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id]


### PR DESCRIPTION
v1.58.1 filtered the data source on the peer transit-gateway-id, but a pendingAcceptance peering only shows under the requester TGW — so same-account/same-region peerings were never found, the accepter never ran, and the peering stayed stuck in pendingAcceptance.

Fix: key the lookup on transit-gateway-attachment-id only (already unique, so the "multiple matched" fix stays intact) — finds the attachment in every state and lets the accepter accept it in the same apply.

## Related Issues
- https://github.com/wso2-enterprise/wso2cloud/issues/762
- https://github.com/wso2-enterprise/wso2-paas/issues/31