### PR TITLE
fix(tgw-peering): reverts the peering lookup back to the v1.57.3 approach.

### DIFF
--- a/modules/aws/Transit-Gateway-Peering/outputs.tf
+++ b/modules/aws/Transit-Gateway-Peering/outputs.tf
@@ -2,6 +2,5 @@ output "local_transit_gateway_attachment_id" {
   value = aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id
 }
 output "peer_transit_gateway_attachment_id" {
-  # Same attachment (one id shared by both TGWs); use the created resource, not a lookup.
-  value = aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id
+  value = data.aws_ec2_transit_gateway_peering_attachment.peer_transit_gateway_peering_attachment.id
 }

--- a/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
+++ b/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
@@ -16,16 +16,19 @@ resource "aws_ec2_transit_gateway_peering_attachment" "transit_gateway_peering_a
   transit_gateway_id      = var.local_transit_gateway_id
   tags                    = var.default_tags
 }
-# Look up the attachment by its id alone; the id is unique and resolves in every state.
+# Resolve the accepter-side record; only that side can be accepted.
 data "aws_ec2_transit_gateway_peering_attachment" "peer_transit_gateway_peering_attachment" {
   filter {
-    name   = "transit-gateway-attachment-id"
-    values = [aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id]
+    name   = "transit-gateway-id"
+    values = [var.peer_transit_gateway_id]
   }
+  filter {
+    name   = "state"
+    values = ["available", "pendingAcceptance", "pending"]
+  }
+
   depends_on = [aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment]
 }
-
-# Accept from the peer side via the data source (accepting via the resource id is rejected by AWS).
 resource "aws_ec2_transit_gateway_peering_attachment_accepter" "transit_gateway_peering_attachment_accepter" {
   transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.peer_transit_gateway_peering_attachment.id
 }


### PR DESCRIPTION
## Summary:
Reverts the peering lookup back to the v1.57.3 approach.

## Related Issues
- https://github.com/wso2-enterprise/wso2cloud/issues/762
- https://github.com/wso2-enterprise/wso2-paas/issues/31