### PR TITLE
fix(tgw-peering): resolve attachment by adding extra requester parameter to accept multiple tgw peering connections

### DIFF
--- a/modules/aws/Transit-Gateway-Peering/outputs.tf
+++ b/modules/aws/Transit-Gateway-Peering/outputs.tf
@@ -2,5 +2,5 @@ output "local_transit_gateway_attachment_id" {
   value = aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment.id
 }
 output "peer_transit_gateway_attachment_id" {
-  value = data.aws_ec2_transit_gateway_peering_attachment.peer_transit_gateway_peering_attachment.id
+  value = data.aws_ec2_transit_gateway_attachment.peer_transit_gateway_peering_attachment.id
 }

--- a/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
+++ b/modules/aws/Transit-Gateway-Peering/transit-gateway-peering.tf
@@ -16,19 +16,23 @@ resource "aws_ec2_transit_gateway_peering_attachment" "transit_gateway_peering_a
   transit_gateway_id      = var.local_transit_gateway_id
   tags                    = var.default_tags
 }
-# Resolve the accepter-side record; only that side can be accepted.
-data "aws_ec2_transit_gateway_peering_attachment" "peer_transit_gateway_peering_attachment" {
+# Resolve by peer TGW + requester TGW so the lookup stays unique across multiple peerings.
+data "aws_ec2_transit_gateway_attachment" "peer_transit_gateway_peering_attachment" {
   filter {
     name   = "transit-gateway-id"
     values = [var.peer_transit_gateway_id]
   }
   filter {
-    name   = "state"
-    values = ["available", "pendingAcceptance", "pending"]
+    name   = "resource-id"
+    values = [var.local_transit_gateway_id]
+  }
+  filter {
+    name   = "resource-type"
+    values = ["peering"]
   }
 
   depends_on = [aws_ec2_transit_gateway_peering_attachment.transit_gateway_peering_attachment]
 }
 resource "aws_ec2_transit_gateway_peering_attachment_accepter" "transit_gateway_peering_attachment_accepter" {
-  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_peering_attachment.peer_transit_gateway_peering_attachment.id
+  transit_gateway_attachment_id = data.aws_ec2_transit_gateway_attachment.peer_transit_gateway_peering_attachment.id
 }


### PR DESCRIPTION
## Summary

The module resolved the attachment to accept via data "aws_ec2_transit_gateway_peering_attachment" filtered only by transit-gateway-id. That filter matches every peering on the TGW, so as soon as a second peering exists on the same TGW, the singular data source fails at plan/refresh with:

Error: multiple EC2 Transit Gateway Peering Attachments matched

This blocks every plan/apply on the layer until resolved.

## Fix

Switch to the generic data "aws_ec2_transit_gateway_attachment", which supports resource-id, and filter on the unique pair:

- transit-gateway-id = peer TGW
- resource-id = requester TGW
- resource-type = peering

This resolves to exactly one attachment even when the TGW has multiple peerings.

## Related Issues
- https://github.com/wso2-enterprise/wso2cloud/issues/762
- https://github.com/wso2-enterprise/wso2-paas/issues/31