### PR TITLE
Add cloudfront functions support and improve WAF capabilities

### DIFF
--- a/modules/aws/Amazon-Issued-ACM-Certificate/variables.tf
+++ b/modules/aws/Amazon-Issued-ACM-Certificate/variables.tf
@@ -28,7 +28,8 @@ variable "hosted_zone_id" {
   type        = string
   default     = null
   validation {
-    condition     = var.hosted_zone_id == null || length(trimspace(var.hosted_zone_id)) > 0
+    # Ternary (not ||) so trimspace() is never evaluated on a null hosted_zone_id.
+    condition     = var.hosted_zone_id == null ? true : length(trimspace(var.hosted_zone_id)) > 0
     error_message = "hosted_zone_id must be null or a non-empty Route53 hosted zone ID."
   }
 }

--- a/modules/aws/CloudWatch-Event-Rule/main.tf
+++ b/modules/aws/CloudWatch-Event-Rule/main.tf
@@ -19,7 +19,7 @@
 # --------------------------------------------------------------------------------------
 
 resource "aws_cloudwatch_event_rule" "rule" {
-  name                = join("-", [var.name, var.abbreviation])
+  name                = var.abbreviation != null && var.abbreviation != "" ? join("-", [var.name, var.abbreviation]) : var.name
   description         = var.description
   event_pattern       = var.event_pattern
   schedule_expression = var.schedule_expression

--- a/modules/aws/CloudWatch-Event-Rule/variables.tf
+++ b/modules/aws/CloudWatch-Event-Rule/variables.tf
@@ -24,7 +24,7 @@ variable "name" {
 }
 
 variable "abbreviation" {
-  description = "Abbreviation of the rule name"
+  description = "Suffix appended to the rule name as \"<name>-<abbreviation>\". Default kept as \"rule\" for backward compatibility with existing callers that don't set this - pass null/empty explicitly to use name as-is instead."
   type        = string
   default     = "rule"
 }

--- a/modules/aws/Cloudfront-Function/main.tf
+++ b/modules/aws/Cloudfront-Function/main.tf
@@ -1,0 +1,27 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "aws_cloudfront_function" "function" {
+  name    = var.name
+  runtime = var.runtime
+  comment = var.comment
+  code    = var.code
+  publish = var.publish
+}

--- a/modules/aws/Cloudfront-Function/outputs.tf
+++ b/modules/aws/Cloudfront-Function/outputs.tf
@@ -1,0 +1,34 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "arn" {
+  description = "ARN of the CloudFront Function (used for function_association)."
+  value       = aws_cloudfront_function.function.arn
+}
+
+output "name" {
+  description = "Name of the CloudFront Function."
+  value       = aws_cloudfront_function.function.name
+}
+
+output "status" {
+  description = "Deployment status of the CloudFront Function."
+  value       = aws_cloudfront_function.function.status
+}

--- a/modules/aws/Cloudfront-Function/variables.tf
+++ b/modules/aws/Cloudfront-Function/variables.tf
@@ -1,0 +1,52 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name of the CloudFront Function (unique within the account)."
+  type        = string
+}
+
+variable "runtime" {
+  description = "CloudFront Function runtime."
+  type        = string
+  default     = "cloudfront-js-2.0"
+
+  validation {
+    condition     = contains(["cloudfront-js-1.0", "cloudfront-js-2.0"], var.runtime)
+    error_message = "runtime must be one of: cloudfront-js-1.0, cloudfront-js-2.0."
+  }
+}
+
+variable "comment" {
+  description = "Comment describing the function."
+  type        = string
+  default     = null
+}
+
+variable "code" {
+  description = "The JavaScript source code of the function."
+  type        = string
+}
+
+variable "publish" {
+  description = "Whether to publish the function to the LIVE stage on create/update."
+  type        = bool
+  default     = true
+}

--- a/modules/aws/Cloudfront-Function/versions.tf
+++ b/modules/aws/Cloudfront-Function/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.3.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/modules/aws/Cloudfront-Response-Headers-Policy/main.tf
+++ b/modules/aws/Cloudfront-Response-Headers-Policy/main.tf
@@ -1,0 +1,91 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+resource "aws_cloudfront_response_headers_policy" "policy" {
+  name    = var.name
+  comment = var.comment
+
+  security_headers_config {
+    dynamic "strict_transport_security" {
+      for_each = var.strict_transport_security != null ? [var.strict_transport_security] : []
+      content {
+        access_control_max_age_sec = strict_transport_security.value.access_control_max_age_sec
+        include_subdomains         = strict_transport_security.value.include_subdomains
+        preload                    = strict_transport_security.value.preload
+        override                   = strict_transport_security.value.override
+      }
+    }
+
+    dynamic "content_type_options" {
+      for_each = var.content_type_options_override != null ? [1] : []
+      content {
+        override = var.content_type_options_override
+      }
+    }
+
+    dynamic "frame_options" {
+      for_each = var.frame_options != null ? [var.frame_options] : []
+      content {
+        frame_option = frame_options.value.frame_option
+        override     = frame_options.value.override
+      }
+    }
+
+    dynamic "referrer_policy" {
+      for_each = var.referrer_policy != null ? [var.referrer_policy] : []
+      content {
+        referrer_policy = referrer_policy.value.referrer_policy
+        override        = referrer_policy.value.override
+      }
+    }
+
+    dynamic "xss_protection" {
+      for_each = var.xss_protection != null ? [var.xss_protection] : []
+      content {
+        protection = xss_protection.value.protection
+        mode_block = xss_protection.value.mode_block
+        override   = xss_protection.value.override
+        report_uri = xss_protection.value.report_uri
+      }
+    }
+
+    dynamic "content_security_policy" {
+      for_each = var.content_security_policy != null ? [var.content_security_policy] : []
+      content {
+        content_security_policy = content_security_policy.value.content_security_policy
+        override                = content_security_policy.value.override
+      }
+    }
+  }
+
+  dynamic "custom_headers_config" {
+    for_each = length(var.custom_headers) > 0 ? [1] : []
+    content {
+      dynamic "items" {
+        for_each = var.custom_headers
+        content {
+          header   = items.key
+          value    = items.value.value
+          override = items.value.override
+        }
+      }
+    }
+  }
+}

--- a/modules/aws/Cloudfront-Response-Headers-Policy/outputs.tf
+++ b/modules/aws/Cloudfront-Response-Headers-Policy/outputs.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "id" {
+  description = "ID of the response headers policy."
+  value       = aws_cloudfront_response_headers_policy.policy.id
+}
+
+output "name" {
+  description = "Name of the response headers policy."
+  value       = aws_cloudfront_response_headers_policy.policy.name
+}

--- a/modules/aws/Cloudfront-Response-Headers-Policy/variables.tf
+++ b/modules/aws/Cloudfront-Response-Headers-Policy/variables.tf
@@ -69,6 +69,20 @@ variable "referrer_policy" {
     override        = optional(bool, true)
   })
   default = null
+
+  validation {
+    condition = var.referrer_policy == null || contains([
+      "no-referrer",
+      "no-referrer-when-downgrade",
+      "origin",
+      "origin-when-cross-origin",
+      "same-origin",
+      "strict-origin",
+      "strict-origin-when-cross-origin",
+      "unsafe-url",
+    ], try(var.referrer_policy.referrer_policy, ""))
+    error_message = "referrer_policy.referrer_policy must be one of: no-referrer, no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url."
+  }
 }
 
 variable "xss_protection" {
@@ -80,6 +94,11 @@ variable "xss_protection" {
     report_uri = optional(string)
   })
   default = null
+
+  validation {
+    condition     = var.xss_protection == null || !(try(var.xss_protection.mode_block, false) && try(var.xss_protection.report_uri, null) != null)
+    error_message = "xss_protection.mode_block and xss_protection.report_uri cannot both be set; CloudFront rejects this combination."
+  }
 }
 
 variable "content_security_policy" {

--- a/modules/aws/Cloudfront-Response-Headers-Policy/variables.tf
+++ b/modules/aws/Cloudfront-Response-Headers-Policy/variables.tf
@@ -1,0 +1,101 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Unique name for the response headers policy."
+  type        = string
+}
+
+variable "comment" {
+  description = "Comment describing the policy."
+  type        = string
+  default     = null
+}
+
+# --- Security headers (each sub-block is optional; omit to leave that header unmanaged) ------
+
+variable "strict_transport_security" {
+  description = "HSTS. Set null to omit."
+  type = object({
+    access_control_max_age_sec = number
+    include_subdomains         = optional(bool, false)
+    preload                    = optional(bool, false)
+    override                   = optional(bool, true)
+  })
+  default = null
+}
+
+variable "content_type_options_override" {
+  description = "When set, emit X-Content-Type-Options: nosniff with this override flag. Set null to omit."
+  type        = bool
+  default     = null
+}
+
+variable "frame_options" {
+  description = "X-Frame-Options. frame_option must be DENY or SAMEORIGIN. Set null to omit."
+  type = object({
+    frame_option = string
+    override     = optional(bool, true)
+  })
+  default = null
+
+  validation {
+    condition     = var.frame_options == null || contains(["DENY", "SAMEORIGIN"], try(var.frame_options.frame_option, ""))
+    error_message = "frame_options.frame_option must be DENY or SAMEORIGIN."
+  }
+}
+
+variable "referrer_policy" {
+  description = "Referrer-Policy. Set null to omit."
+  type = object({
+    referrer_policy = string
+    override        = optional(bool, true)
+  })
+  default = null
+}
+
+variable "xss_protection" {
+  description = "X-XSS-Protection. Set null to omit."
+  type = object({
+    protection = bool
+    mode_block = optional(bool, true)
+    override   = optional(bool, true)
+    report_uri = optional(string)
+  })
+  default = null
+}
+
+variable "content_security_policy" {
+  description = "Content-Security-Policy. Prefer setting per-host CSP in a CloudFront Function; use this only for a single static CSP. Set null to omit."
+  type = object({
+    content_security_policy = string
+    override                = optional(bool, true)
+  })
+  default = null
+}
+
+variable "custom_headers" {
+  description = "Additional custom response headers. Map of header name -> { value, override }."
+  type = map(object({
+    value    = string
+    override = optional(bool, true)
+  }))
+  default = {}
+}

--- a/modules/aws/Cloudfront-Response-Headers-Policy/versions.tf
+++ b/modules/aws/Cloudfront-Response-Headers-Policy/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.3.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/modules/aws/Cloudfront-VPC-Origin/outputs.tf
+++ b/modules/aws/Cloudfront-VPC-Origin/outputs.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+output "vpc_origin_id" {
+  description = "ID of the CloudFront VPC origin"
+  value       = aws_cloudfront_vpc_origin.vpc_origin.id
+}
+
+output "vpc_origin_arn" {
+  description = "ARN of the CloudFront VPC origin"
+  value       = aws_cloudfront_vpc_origin.vpc_origin.arn
+}

--- a/modules/aws/Cloudfront-VPC-Origin/variables.tf
+++ b/modules/aws/Cloudfront-VPC-Origin/variables.tf
@@ -1,0 +1,59 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name of the CloudFront VPC origin"
+  type        = string
+}
+
+variable "origin_arn" {
+  description = "ARN of the internal ALB / NLB / EC2 the VPC origin points to"
+  type        = string
+}
+
+variable "http_port" {
+  description = "HTTP port CloudFront uses to connect to the origin"
+  type        = number
+  default     = 80
+}
+
+variable "https_port" {
+  description = "HTTPS port CloudFront uses to connect to the origin"
+  type        = number
+  default     = 443
+}
+
+variable "origin_protocol_policy" {
+  description = "Origin protocol policy (http-only, https-only, match-viewer)"
+  type        = string
+  default     = "https-only"
+}
+
+variable "origin_ssl_protocols" {
+  description = "SSL/TLS protocols CloudFront uses when connecting to the origin over HTTPS"
+  type        = list(string)
+  default     = ["TLSv1.2"]
+}
+
+variable "tags" {
+  description = "Tags to apply to the VPC origin"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/aws/Cloudfront-VPC-Origin/versions.tf
+++ b/modules/aws/Cloudfront-VPC-Origin/versions.tf
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.3.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.82.0" # aws_cloudfront_vpc_origin added in provider v5.82.0
+    }
+  }
+}

--- a/modules/aws/Cloudfront-VPC-Origin/vpc_origin.tf
+++ b/modules/aws/Cloudfront-VPC-Origin/vpc_origin.tf
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+#
+# CloudFront VPC Origin — private connectivity from CloudFront to an internal ALB/NLB/EC2
+# via AWS-managed ENIs (requires aws provider >= 5.82.0).
+# --------------------------------------------------------------------------------------
+
+resource "aws_cloudfront_vpc_origin" "vpc_origin" {
+  vpc_origin_endpoint_config {
+    name                   = var.name
+    arn                    = var.origin_arn
+    http_port              = var.http_port
+    https_port             = var.https_port
+    origin_protocol_policy = var.origin_protocol_policy
+
+    origin_ssl_protocols {
+      items    = var.origin_ssl_protocols
+      quantity = length(var.origin_ssl_protocols)
+    }
+  }
+
+  tags = var.tags
+}

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -90,19 +90,36 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
     min_ttl                = var.min_ttl
     default_ttl            = var.default_ttl
     max_ttl                = var.max_ttl
+
+    dynamic "function_association" {
+      for_each = var.default_function_associations
+      content {
+        event_type   = function_association.value.event_type
+        function_arn = function_association.value.function_arn
+      }
+    }
   }
 
   dynamic "ordered_cache_behavior" {
     for_each = var.ordered_cache_behaviors
     content {
-      path_pattern             = ordered_cache_behavior.value.path_pattern
-      target_origin_id         = ordered_cache_behavior.value.target_origin_id
-      compress                 = ordered_cache_behavior.value.compress
-      viewer_protocol_policy   = ordered_cache_behavior.value.viewer_protocol_policy
-      allowed_methods          = ordered_cache_behavior.value.allowed_methods
-      cached_methods           = ordered_cache_behavior.value.cached_methods
-      cache_policy_id          = ordered_cache_behavior.value.cache_policy_id
-      origin_request_policy_id = ordered_cache_behavior.value.origin_request_policy_id
+      path_pattern               = ordered_cache_behavior.value.path_pattern
+      target_origin_id           = ordered_cache_behavior.value.target_origin_id
+      compress                   = ordered_cache_behavior.value.compress
+      viewer_protocol_policy     = ordered_cache_behavior.value.viewer_protocol_policy
+      allowed_methods            = ordered_cache_behavior.value.allowed_methods
+      cached_methods             = ordered_cache_behavior.value.cached_methods
+      cache_policy_id            = ordered_cache_behavior.value.cache_policy_id
+      origin_request_policy_id   = ordered_cache_behavior.value.origin_request_policy_id
+      response_headers_policy_id = ordered_cache_behavior.value.response_headers_policy_id
+
+      dynamic "function_association" {
+        for_each = ordered_cache_behavior.value.function_associations
+        content {
+          event_type   = function_association.value.event_type
+          function_arn = function_association.value.function_arn
+        }
+      }
 
       dynamic "forwarded_values" {
         for_each = ordered_cache_behavior.value.cache_policy_id == null ? [1] : []

--- a/modules/aws/Cloudfront/cloudfront.tf
+++ b/modules/aws/Cloudfront/cloudfront.tf
@@ -23,11 +23,25 @@ resource "aws_cloudfront_distribution" "cloudfront_distribution" {
     domain_name = var.dns_name
     origin_id   = var.origin_id
 
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = var.origin_protocol_policy
-      origin_ssl_protocols   = var.origin_ssl_protocols
+    # VPC-origin path: when vpc_origin_id is set, CloudFront reaches a private ALB/NLB/EC2
+    # via managed ENIs (custom_origin_config must be absent). domain_name is still required
+    # and is used as the SNI/Host + for origin certificate SAN validation.
+    dynamic "vpc_origin_config" {
+      for_each = var.vpc_origin_id != null ? [1] : []
+      content {
+        vpc_origin_id = var.vpc_origin_id
+      }
+    }
+
+    # Public/custom-origin path (default; unchanged when vpc_origin_id is null).
+    dynamic "custom_origin_config" {
+      for_each = var.vpc_origin_id == null ? [1] : []
+      content {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = var.origin_protocol_policy
+        origin_ssl_protocols   = var.origin_ssl_protocols
+      }
     }
 
     dynamic "origin_shield" {

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -19,8 +19,14 @@
 # --------------------------------------------------------------------------------------
 
 variable "dns_name" {
-  description = "The DNS name of the origin"
+  description = "The DNS name of the origin. For a VPC origin this is not resolved for routing; it is used only as the SNI/Host and for origin-certificate SAN validation, so it must be a host covered by the origin cert."
   type        = string
+}
+
+variable "vpc_origin_id" {
+  description = "ID of an aws_cloudfront_vpc_origin. When set, the origin uses vpc_origin_config (private ALB/NLB/EC2) instead of custom_origin_config. Default null keeps the existing custom-origin behavior."
+  type        = string
+  default     = null
 }
 
 variable "origin_id" {

--- a/modules/aws/Cloudfront/variables.tf
+++ b/modules/aws/Cloudfront/variables.tf
@@ -136,8 +136,51 @@ variable "ordered_cache_behaviors" {
     compress                 = bool
     cache_policy_id          = optional(string)
     origin_request_policy_id = optional(string)
+    # Optional response headers policy for this behavior (e.g. static security headers).
+    response_headers_policy_id = optional(string)
+    # Optional CloudFront Function associations for this behavior. At most one per event_type
+    # ("viewer-request" | "viewer-response"). Default [] keeps existing callers unchanged.
+    function_associations = optional(list(object({
+      event_type   = string
+      function_arn = string
+    })), [])
   }))
   default = []
+
+  # CloudFront allows at most one function association per event type per behavior.
+  validation {
+    condition = alltrue([
+      for b in var.ordered_cache_behaviors : alltrue([
+        for fa in b.function_associations : contains(["viewer-request", "viewer-response"], fa.event_type)
+      ])
+    ])
+    error_message = "ordered_cache_behaviors[*].function_associations[*].event_type must be one of: viewer-request, viewer-response."
+  }
+  validation {
+    condition = alltrue([
+      for b in var.ordered_cache_behaviors :
+      length(b.function_associations) == length(distinct([for fa in b.function_associations : fa.event_type]))
+    ])
+    error_message = "Each event_type may appear at most once per ordered_cache_behavior (one viewer-request and/or one viewer-response)."
+  }
+}
+
+variable "default_function_associations" {
+  description = "CloudFront Function associations for the default cache behavior. At most one per event_type (viewer-request | viewer-response)."
+  type = list(object({
+    event_type   = string
+    function_arn = string
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for fa in var.default_function_associations : contains(["viewer-request", "viewer-response"], fa.event_type)])
+    error_message = "default_function_associations[*].event_type must be one of: viewer-request, viewer-response."
+  }
+  validation {
+    condition     = length(var.default_function_associations) == length(distinct([for fa in var.default_function_associations : fa.event_type]))
+    error_message = "Each event_type may appear at most once in default_function_associations."
+  }
 }
 
 variable "enable_logging_config" {

--- a/modules/aws/Cloudfront/versions.tf
+++ b/modules/aws/Cloudfront/versions.tf
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.82.0"
     }
   }
 }

--- a/modules/aws/EFS/efs.tf
+++ b/modules/aws/EFS/efs.tf
@@ -20,7 +20,18 @@ resource "aws_efs_file_system" "efs_file_system" {
 
   creation_token = var.creation_token
 
+  dynamic "protection" {
+    for_each = var.replication_overwrite_protection == null ? [] : [var.replication_overwrite_protection]
+    content {
+      replication_overwrite = protection.value
+    }
+  }
+
   tags = local.tags
+
+  lifecycle {
+    ignore_changes = [protection]
+  }
 }
 
 resource "aws_efs_access_point" "efs_access_point" {

--- a/modules/aws/EFS/variables.tf
+++ b/modules/aws/EFS/variables.tf
@@ -24,6 +24,15 @@ variable "kms_key_id" {
   type        = string
   default     = null
 }
+variable "replication_overwrite_protection" {
+  description = "Whether this file system may be designated as an EFS Replication destination. AWS defaults new file systems to ENABLED (blocks it). Set to DISABLED to allow aws_efs_replication_configuration to target this file system — otherwise CreateReplicationConfiguration fails with 'has replication overwrite protection enabled'. Leave null (unset) to keep the AWS default."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.replication_overwrite_protection == null ? true : contains(["ENABLED", "DISABLED"], var.replication_overwrite_protection)
+    error_message = "replication_overwrite_protection must be \"ENABLED\", \"DISABLED\", or null."
+  }
+}
 variable "performance_mode" {
   description = "The performance mode of the file system"
   type        = string

--- a/modules/aws/EFS/versions.tf
+++ b/modules/aws/EFS/versions.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.32.0"
     }
   }
 }

--- a/modules/aws/EKS-Cluster/data.tf
+++ b/modules/aws/EKS-Cluster/data.tf
@@ -8,16 +8,18 @@
 # You may not alter or remove any copyright or other notice from copies of this content.
 #
 # --------------------------------------------------------------------------------------
-data "aws_eks_cluster" "eks_cluster" {
-  name = join("-", [var.project, var.application, var.environment, var.region, "eks"])
+# (Removed: data.aws_eks_cluster.eks_cluster - a pure roundtrip for values the
+# aws_eks_cluster.eks_cluster resource (eks.tf) already exposes directly, and being an
+# unconditional data source with depends_on the very resource it duplicates, it forced
+# Terraform to defer reading it until apply on ANY change to the cluster (even unrelated
+# tag updates) - marking oidc.issuer "known after apply" and forcing a spurious replace of
+# the (immutable-url) OIDC provider resource in iam_role.tf. Referencing the resource
+# directly makes url/thumbprint_list track genuine issuer/certificate changes correctly,
+# without ignore_changes masking real rotations.
 
-  depends_on = [
-    aws_eks_cluster.eks_cluster
-  ]
-}
 # Obtain TLS certificate for the OIDC provider
 data "tls_certificate" "tls" {
-  url = data.aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
+  url = aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
 }
 
 data "aws_iam_policy_document" "cluster_autoscaler_sts_policy" {

--- a/modules/aws/EKS-Cluster/iam_role.tf
+++ b/modules/aws/EKS-Cluster/iam_role.tf
@@ -63,6 +63,10 @@ resource "aws_iam_openid_connect_provider" "eks_ca_oidc_provider" {
     data.tls_certificate.tls,
     data.aws_eks_cluster.eks_cluster
   ]
+
+  lifecycle {
+    ignore_changes = [url, thumbprint_list]
+  }
 }
 
 # IAM Role for IAM Cluster Autoscaler

--- a/modules/aws/EKS-Cluster/iam_role.tf
+++ b/modules/aws/EKS-Cluster/iam_role.tf
@@ -55,18 +55,14 @@ resource "aws_iam_role_policy_attachment" "amazon_eks_pc_resource_controller" {
 resource "aws_iam_openid_connect_provider" "eks_ca_oidc_provider" {
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = local.oidc_thumbprint
-  url             = data.aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
+  url             = aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
 
   tags = var.tags
 
   depends_on = [
     data.tls_certificate.tls,
-    data.aws_eks_cluster.eks_cluster
+    aws_eks_cluster.eks_cluster
   ]
-
-  lifecycle {
-    ignore_changes = [url, thumbprint_list]
-  }
 }
 
 # IAM Role for IAM Cluster Autoscaler

--- a/modules/aws/EKS-Cluster/outputs.tf
+++ b/modules/aws/EKS-Cluster/outputs.tf
@@ -94,8 +94,8 @@ output "tls_cert_sha1_fingerprint" {
 }
 
 output "eks_cluster_issuer" {
-  value      = data.aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
-  depends_on = [data.aws_eks_cluster.eks_cluster]
+  value      = aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer
+  depends_on = [aws_eks_cluster.eks_cluster]
 }
 
 output "eks_route_table_ids" {

--- a/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
+++ b/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
@@ -9,12 +9,21 @@
 #
 # --------------------------------------------------------------------------------------
 
+locals {
+  # internal_usage_flag is typed string and callers may pass a bool ("true") or string.
+  # Comparing a coerced string ("true") against a bool literal (== true) silently returns
+  # false, so an internal NLB still hit the else-branch and created orphan (unassociated)
+  # EIPs. tobool() normalizes both forms so the branches below are correct.
+  is_internal = tobool(var.internal_usage_flag)
+  is_shielded = tobool(var.enable_shield_protection)
+}
+
 # Ignore: AVD-AWS-0053 (https://avd.aquasec.com/misconfig/aws/elb/avd-aws-0053/)
 # Reason: We may need public load balancers. As such this has been configured as a parameter.
 # trivy:ignore:AVD-AWS-0053
 resource "aws_lb" "lb" {
   name               = join("-", [var.project, var.application, var.environment, var.region, "elb"])
-  internal           = var.internal_usage_flag # Defines the Load balancer network connectivity required by AVD-AWS-0053
+  internal           = local.is_internal # Defines the Load balancer network connectivity required by AVD-AWS-0053
   load_balancer_type = var.load_balancer_type
   security_groups    = var.security_group_ids
 
@@ -27,22 +36,24 @@ resource "aws_lb" "lb" {
   dynamic "subnet_mapping" {
     for_each = var.subnet_ids
     content {
-      subnet_id            = subnet_mapping.value
-      allocation_id        = var.internal_usage_flag == false ? aws_eip.eip[subnet_mapping.key].id : null
-      private_ipv4_address = var.internal_usage_flag == true ? var.private_ip_addresses[subnet_mapping.key] : null
+      subnet_id = subnet_mapping.value
+      # Public NLB: associate an EIP per subnet. Internal NLB: no EIP; use an explicit
+      # private IP only when the caller supplied one (otherwise let AWS auto-assign).
+      allocation_id        = local.is_internal ? null : aws_eip.eip[subnet_mapping.key].id
+      private_ipv4_address = local.is_internal ? lookup(var.private_ip_addresses, subnet_mapping.key, null) : null
     }
   }
 }
 
 resource "aws_eip" "eip" {
-  for_each = var.internal_usage_flag == true ? {} : var.subnet_ids
+  for_each = local.is_internal ? {} : var.subnet_ids
   domain   = "vpc"
 
   tags = var.tags
 }
 
 resource "aws_shield_protection" "shield_protection" {
-  for_each     = var.internal_usage_flag == false && var.enable_shield_protection ? var.subnet_ids : {}
+  for_each     = !local.is_internal && local.is_shielded ? var.subnet_ids : {}
   name         = join("-", [var.project, var.application, var.environment, var.region, each.key, "elb-eip-shield-protection"])
   resource_arn = replace(aws_eip.eip[each.key].arn, "elastic-ip", "eip-allocation")
 

--- a/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
+++ b/modules/aws/Elastic-LoadBalancer/elastic_loadbalancer.tf
@@ -9,21 +9,12 @@
 #
 # --------------------------------------------------------------------------------------
 
-locals {
-  # internal_usage_flag is typed string and callers may pass a bool ("true") or string.
-  # Comparing a coerced string ("true") against a bool literal (== true) silently returns
-  # false, so an internal NLB still hit the else-branch and created orphan (unassociated)
-  # EIPs. tobool() normalizes both forms so the branches below are correct.
-  is_internal = tobool(var.internal_usage_flag)
-  is_shielded = tobool(var.enable_shield_protection)
-}
-
 # Ignore: AVD-AWS-0053 (https://avd.aquasec.com/misconfig/aws/elb/avd-aws-0053/)
 # Reason: We may need public load balancers. As such this has been configured as a parameter.
 # trivy:ignore:AVD-AWS-0053
 resource "aws_lb" "lb" {
   name               = join("-", [var.project, var.application, var.environment, var.region, "elb"])
-  internal           = local.is_internal # Defines the Load balancer network connectivity required by AVD-AWS-0053
+  internal           = var.internal_usage_flag # Defines the Load balancer network connectivity required by AVD-AWS-0053
   load_balancer_type = var.load_balancer_type
   security_groups    = var.security_group_ids
 
@@ -44,14 +35,14 @@ resource "aws_lb" "lb" {
 }
 
 resource "aws_eip" "eip" {
-  for_each = local.is_internal ? {} : var.subnet_ids
+  for_each = var.internal_usage_flag ? {} : var.subnet_ids
   domain   = "vpc"
 
   tags = var.tags
 }
 
 resource "aws_shield_protection" "shield_protection" {
-  for_each     = !local.is_internal && local.is_shielded ? var.subnet_ids : {}
+  for_each     = !var.internal_usage_flag && var.enable_shield_protection ? var.subnet_ids : {}
   name         = join("-", [var.project, var.application, var.environment, var.region, each.key, "elb-eip-shield-protection"])
   resource_arn = replace(aws_eip.eip[each.key].arn, "elastic-ip", "eip-allocation")
 

--- a/modules/aws/Elastic-LoadBalancer/variables.tf
+++ b/modules/aws/Elastic-LoadBalancer/variables.tf
@@ -41,7 +41,7 @@ variable "subnet_ids" {
   default     = {}
 }
 variable "deletion_protection_flag" {
-  type        = string
+  type        = bool
   description = "Flag to indicate whether the ALB instance is protected from accidental termination or not"
   default     = true
 }
@@ -60,12 +60,12 @@ variable "private_ip_addresses" {
   default     = {}
 }
 variable "enable_shield_protection" {
-  type        = string
+  type        = bool
   description = "Flag to indicate whether the ALB instance is protected by AWS Shield or not"
   default     = false
 }
 variable "enable_cross_zone_load_balancing" {
-  type        = string
+  type        = bool
   description = "Flag to indicate whether the cross zone load balancing is enabled for the ALB instance or not"
   default     = false
 }

--- a/modules/aws/Orphan-Resource-Scanner/lambda.tf
+++ b/modules/aws/Orphan-Resource-Scanner/lambda.tf
@@ -37,6 +37,9 @@ data "archive_file" "scanner_lambda" {
   output_path = "${path.module}/scripts/scanner_lambda.zip"
 }
 
+# Ignore: AVD-AWS-0066 (https://avd.aquasec.com/misconfig/aws-0066)
+# Reason: X-Ray tracing not required for this low-volume weekly scheduled scan
+# trivy:ignore:AVD-AWS-0066
 resource "aws_lambda_function" "scanner" {
   filename         = data.archive_file.scanner_lambda.output_path
   function_name    = "${local.name_prefix}-lambda-function"
@@ -63,6 +66,9 @@ resource "aws_lambda_function" "scanner" {
   }
 }
 
+# Ignore: AVD-AWS-0017 (https://avd.aquasec.com/misconfig/aws-0017)
+# Reason: No customer-managed KMS key is provisioned for this module; default CloudWatch encryption applies
+# trivy:ignore:AVD-AWS-0017
 resource "aws_cloudwatch_log_group" "scanner_lambda" {
   name              = "/aws/lambda/${aws_lambda_function.scanner.function_name}"
   retention_in_days = var.log_retention_days

--- a/modules/aws/Orphan-Resource-Scanner/s3.tf
+++ b/modules/aws/Orphan-Resource-Scanner/s3.tf
@@ -20,12 +20,18 @@
 
 # S3 report bucket - stores the weekly CSV reports written by the scanner Lambda.
 
+# Ignore: AVD-AWS-0089 (https://avd.aquasec.com/misconfig/aws-0089)
+# Reason: Access logging not required for this internal reports bucket
+# trivy:ignore:AVD-AWS-0089
 resource "aws_s3_bucket" "reports" {
   bucket        = var.report_bucket_name
   force_destroy = var.force_destroy_bucket
   tags          = local.tags
 }
 
+# Ignore: AVD-AWS-0090 (https://avd.aquasec.com/misconfig/aws-0090)
+# Reason: Reports are regenerated weekly and expired via lifecycle rules, so version history isn't needed
+# trivy:ignore:AVD-AWS-0090
 resource "aws_s3_bucket_versioning" "reports" {
   bucket = aws_s3_bucket.reports.id
   versioning_configuration {

--- a/modules/aws/Orphan-Resource-Scanner/s3.tf
+++ b/modules/aws/Orphan-Resource-Scanner/s3.tf
@@ -33,6 +33,17 @@ resource "aws_s3_bucket_versioning" "reports" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "reports" {
+  bucket                  = aws_s3_bucket.reports.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Ignore: AVD-AWS-0132 (https://avd.aquasec.com/misconfig/aws/ec2/avd-aws-00132)
+# Reason: Report bucket uses SSE-S3 (AES256); no customer-managed KMS key is provisioned for this module
+# trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket_server_side_encryption_configuration" "reports" {
   bucket = aws_s3_bucket.reports.id
   rule {

--- a/modules/aws/RDS-Aurora/rds.tf
+++ b/modules/aws/RDS-Aurora/rds.tf
@@ -94,6 +94,11 @@ resource "aws_rds_cluster" "rds_cluster" {
   }
 
   tags = var.tags
+
+  # When a separate aws_rds_global_cluster resource attaches this cluster to a Global Database AWS sets global_cluster_identifier on the underlying cluster as a side effect. Ignoring changes here makes the external attachment resource the sole owner of that field.
+  lifecycle {
+    ignore_changes = [global_cluster_identifier]
+  }
 }
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
@@ -115,6 +120,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   preferred_maintenance_window = var.preferred_maintenance_window == null ? each.value.preferred_maintenance_window : var.preferred_maintenance_window
 
   publicly_accessible = var.publicly_accessible
+  apply_immediately   = var.apply_immediately
 
   tags = var.tags
 

--- a/modules/aws/RDS-Aurora/variables.tf
+++ b/modules/aws/RDS-Aurora/variables.tf
@@ -145,7 +145,7 @@ variable "preferred_maintenance_window" {
 }
 
 variable "global_cluster_identifier" {
-  description = "Global cluster identifier"
+  description = "Global cluster identifier. Only used at create time — the cluster resource ignores subsequent changes to this field (see rds.tf), since an external aws_rds_global_cluster attachment is the field's owner thereafter."
   type        = string
   default     = null
 }
@@ -206,6 +206,12 @@ variable "engine_lifecycle_support" {
 
 variable "publicly_accessible" {
   description = "Flag to make the DB publicly accessible"
+  type        = bool
+  default     = false
+}
+
+variable "apply_immediately" {
+  description = "Whether cluster-instance modifications apply immediately instead of waiting for the next preferred_maintenance_window"
   type        = bool
   default     = false
 }

--- a/modules/aws/S3-Account/s3_account.tf
+++ b/modules/aws/S3-Account/s3_account.tf
@@ -22,7 +22,7 @@
 # Reason: Logging not required as of now for S3 Buckets, if required it will be added as a separate resource
 # trivy:ignore:AVD-AWS-0089
 resource "aws_s3_bucket" "s3_bucket" {
-  bucket        = join("-", [var.project, var.application, var.environment, var.region, "bucket"])
+  bucket        = coalesce(var.bucket_name, join("-", [var.project, var.application, var.environment, var.region, "bucket"]))
   force_destroy = var.force_destroy
   tags          = var.tags
 }
@@ -72,5 +72,27 @@ resource "aws_s3_bucket_ownership_controls" "s3_bucket_ownership_controls" {
 
   rule {
     object_ownership = var.object_ownership
+  }
+}
+
+resource "aws_s3_bucket_acl" "s3_bucket_acl" {
+  count = var.acl != null ? 1 : 0
+
+  bucket     = aws_s3_bucket.s3_bucket.id
+  acl        = var.acl
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_ownership_controls, aws_s3_bucket_public_access_block.s3_bucket_public_access_block]
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "s3_bucket_lifecycle" {
+  count = var.lifecycle_expiration_days != null ? 1 : 0
+
+  bucket = aws_s3_bucket.s3_bucket.id
+  rule {
+    id     = var.lifecycle_rule_id
+    status = "Enabled"
+    filter {}
+    expiration {
+      days = var.lifecycle_expiration_days
+    }
   }
 }

--- a/modules/aws/S3-Account/variables.tf
+++ b/modules/aws/S3-Account/variables.tf
@@ -96,3 +96,27 @@ variable "object_ownership" {
   type        = string
   default     = "BucketOwnerPreferred"
 }
+
+variable "bucket_name" {
+  description = "Explicit bucket name. Null falls back to the join(project, application, environment, region, \"bucket\") default."
+  type        = string
+  default     = null
+}
+
+variable "acl" {
+  description = "Canned ACL to apply to the bucket, e.g. \"log-delivery-write\". Null skips setting an ACL."
+  type        = string
+  default     = null
+}
+
+variable "lifecycle_expiration_days" {
+  description = "Days after which objects expire. Null skips creating a lifecycle rule."
+  type        = number
+  default     = null
+}
+
+variable "lifecycle_rule_id" {
+  description = "ID of the expiration lifecycle rule, when lifecycle_expiration_days is set"
+  type        = string
+  default     = "expire-objects"
+}

--- a/modules/aws/Security-Group-Rule/security_group_rules.tf
+++ b/modules/aws/Security-Group-Rule/security_group_rules.tf
@@ -12,11 +12,13 @@
 resource "aws_security_group_rule" "security_group_rule" {
   count = length(var.rules)
 
-  security_group_id = var.security_group_id
-  type              = var.rules[count.index].direction
-  from_port         = var.rules[count.index].from_port
-  to_port           = var.rules[count.index].to_port
-  protocol          = var.rules[count.index].protocol
-  cidr_blocks       = var.rules[count.index].cidr_blocks
-  prefix_list_ids   = var.rules[count.index].prefix_list_ids
+  security_group_id        = var.security_group_id
+  type                     = var.rules[count.index].direction
+  from_port                = var.rules[count.index].from_port
+  to_port                  = var.rules[count.index].to_port
+  protocol                 = var.rules[count.index].protocol
+  description              = var.rules[count.index].description
+  cidr_blocks              = length(coalesce(var.rules[count.index].cidr_blocks, [])) > 0 ? var.rules[count.index].cidr_blocks : null
+  prefix_list_ids          = length(coalesce(var.rules[count.index].prefix_list_ids, [])) > 0 ? var.rules[count.index].prefix_list_ids : null
+  source_security_group_id = try(var.rules[count.index].security_groups[0], null)
 }

--- a/modules/aws/Security-Group-Rule/variables.tf
+++ b/modules/aws/Security-Group-Rule/variables.tf
@@ -18,6 +18,7 @@ variable "rules" {
     cidr_blocks     = list(string)
     security_groups = list(string)
     prefix_list_ids = list(string)
+    description     = optional(string)
   }))
   description = "List of rules to be added to the security group"
 }

--- a/modules/aws/WAF-Web-ACL/variables.tf
+++ b/modules/aws/WAF-Web-ACL/variables.tf
@@ -512,6 +512,42 @@ variable "rules" {
     error_message = "Each statement inside scope_down_statement.and_statement.statements / or_statement.statements (and their not_statement-nested variants) must specify exactly one of byte_match_statement or ip_set_reference_statement."
   }
 
+  # Validation 7 (rate-based): and_statement / or_statement inside rate_based_statement.scope_down_statement (directly or under not_statement) must each contain >= 2 statements.
+  validation {
+    condition = alltrue(flatten([
+      for v in var.rules : [
+        for stmts in [
+          try(v.rate_based_statement.scope_down_statement.and_statement.statements, null),
+          try(v.rate_based_statement.scope_down_statement.or_statement.statements, null),
+          try(v.rate_based_statement.scope_down_statement.not_statement.and_statement.statements, null),
+          try(v.rate_based_statement.scope_down_statement.not_statement.or_statement.statements, null),
+        ] :
+        length(stmts) >= 2
+        if stmts != null
+      ]
+    ]))
+    error_message = "and_statement / or_statement inside rate_based_statement.scope_down_statement must contain at least 2 statements."
+  }
+
+  # Validation 8 (rate-based): each entry in rate_based_statement.scope_down_statement.and_statement.statements, or_statement.statements, and the same lists under not_statement, must specify exactly one of byte_match_statement or ip_set_reference_statement.
+  validation {
+    condition = alltrue(flatten([
+      for v in var.rules : [
+        for stmts in [
+          try(v.rate_based_statement.scope_down_statement.and_statement.statements, null),
+          try(v.rate_based_statement.scope_down_statement.or_statement.statements, null),
+          try(v.rate_based_statement.scope_down_statement.not_statement.and_statement.statements, null),
+          try(v.rate_based_statement.scope_down_statement.not_statement.or_statement.statements, null),
+          ] : [
+          for s in(stmts != null ? stmts : []) :
+          (try(s.byte_match_statement, null) != null ? 1 : 0) +
+          (try(s.ip_set_reference_statement, null) != null ? 1 : 0) == 1
+        ]
+      ]
+    ]))
+    error_message = "Each statement inside rate_based_statement.scope_down_statement.and_statement.statements / or_statement.statements (and their not_statement-nested variants) must specify exactly one of byte_match_statement or ip_set_reference_statement."
+  }
+
   # Validation 9: rate_based_statement.scope_down_statement must specify exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or_statement, or not_statement.
   validation {
     condition = alltrue([
@@ -536,6 +572,31 @@ variable "rules" {
       if try(v.rate_based_statement.scope_down_statement.not_statement, null) != null
     ])
     error_message = "rate_based_statement.scope_down_statement.not_statement must contain exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or or_statement."
+  }
+
+  # Validation 11: Ensure exactly one field_to_match selector is set inside every byte_match_statement under managed_rule_group_statement.scope_down_statement and rate_based_statement.scope_down_statement (top-level, and/or list entries, not_statement, and not_statement-nested and/or).
+  validation {
+    condition = alltrue(flatten([
+      for v in var.rules : [
+        for sds in [
+          try(v.managed_rule_group_statement.scope_down_statement, null),
+          try(v.rate_based_statement.scope_down_statement, null),
+          ] : [
+          for bm in concat(
+            [try(sds.byte_match_statement, null)],
+            [try(sds.not_statement.byte_match_statement, null)],
+            [for s in try(sds.and_statement.statements, []) : try(s.byte_match_statement, null)],
+            [for s in try(sds.or_statement.statements, []) : try(s.byte_match_statement, null)],
+            [for s in try(sds.not_statement.and_statement.statements, []) : try(s.byte_match_statement, null)],
+            [for s in try(sds.not_statement.or_statement.statements, []) : try(s.byte_match_statement, null)],
+          ) :
+          (try(bm.field_to_match.uri_path, false) == true ? 1 : 0) + (try(bm.field_to_match.single_header, null) != null ? 1 : 0) == 1
+          if bm != null
+        ]
+        if sds != null
+      ]
+    ]))
+    error_message = "Inside every byte_match_statement under managed_rule_group_statement.scope_down_statement and rate_based_statement.scope_down_statement, exactly one field_to_match selector (uri_path or single_header) must be set."
   }
 }
 

--- a/modules/aws/WAF-Web-ACL/variables.tf
+++ b/modules/aws/WAF-Web-ACL/variables.tf
@@ -106,6 +106,14 @@ variable "rules" {
     allowed_ip_set_arn = optional(string)
     blocked_ip_set_arn = optional(string)
     host_header        = optional(string)
+    # Geo match statement — match requests by ISO 3166-1 alpha-2 country codes; omit forwarded_ip_config unless a client-supplied header must be honored (spoofable, and unnecessary at CLOUDFRONT scope).
+    geo_match_statement = optional(object({
+      country_codes = list(string)
+      forwarded_ip_config = optional(object({
+        header_name       = string
+        fallback_behavior = string # MATCH | NO_MATCH
+      }))
+    }))
     managed_rule_group_statement = optional(object({
       name        = string
       vendor_name = string
@@ -113,13 +121,7 @@ variable "rules" {
         name   = string
         action = string # count, allow, block
       })), [])
-      # Optional scope-down: restrict the managed rule group to a subset of requests.
-      # Supports byte_match_statement, ip_set_reference_statement, and_statement, or_statement,
-      # and not_statement (wrapping any of the above) at the top level. Inside and_statement /
-      # or_statement statements, each entry must be exactly one of byte_match_statement OR
-      # ip_set_reference_statement. Use not_statement+ip_set_reference to SKIP a managed rule
-      # group for trusted source IPs (e.g. internal NAT egress); use not_statement+or with
-      # mixed byte_match + ip_set_reference entries to combine path-based and IP-based skips.
+      # Optional scope-down restricting the managed rule group to a subset of requests via byte_match/ip_set_reference/and/or/not statements; e.g. not_statement+ip_set_reference skips trusted IPs, not_statement+or combines path- and IP-based skips.
       scope_down_statement = optional(object({
         byte_match_statement = optional(object({
           search_string         = string
@@ -234,6 +236,117 @@ variable "rules" {
     rate_based_statement = optional(object({
       limit              = number
       aggregate_key_type = string
+      # Optional scope-down to count only requests matching this statement (per-URI/per-host rate limits); same shape as managed_rule_group_statement.scope_down_statement.
+      scope_down_statement = optional(object({
+        byte_match_statement = optional(object({
+          search_string         = string
+          positional_constraint = string
+          field_to_match = object({
+            uri_path      = optional(bool)
+            single_header = optional(string)
+          })
+          text_transformation = object({
+            priority = number
+            type     = string
+          })
+        }))
+        ip_set_reference_statement = optional(object({
+          arn = string
+        }))
+        and_statement = optional(object({
+          statements = list(object({
+            byte_match_statement = optional(object({
+              search_string         = string
+              positional_constraint = string
+              field_to_match = object({
+                uri_path      = optional(bool)
+                single_header = optional(string)
+              })
+              text_transformation = object({
+                priority = number
+                type     = string
+              })
+            }))
+            ip_set_reference_statement = optional(object({
+              arn = string
+            }))
+          }))
+        }))
+        or_statement = optional(object({
+          statements = list(object({
+            byte_match_statement = optional(object({
+              search_string         = string
+              positional_constraint = string
+              field_to_match = object({
+                uri_path      = optional(bool)
+                single_header = optional(string)
+              })
+              text_transformation = object({
+                priority = number
+                type     = string
+              })
+            }))
+            ip_set_reference_statement = optional(object({
+              arn = string
+            }))
+          }))
+        }))
+        not_statement = optional(object({
+          byte_match_statement = optional(object({
+            search_string         = string
+            positional_constraint = string
+            field_to_match = object({
+              uri_path      = optional(bool)
+              single_header = optional(string)
+            })
+            text_transformation = object({
+              priority = number
+              type     = string
+            })
+          }))
+          ip_set_reference_statement = optional(object({
+            arn = string
+          }))
+          and_statement = optional(object({
+            statements = list(object({
+              byte_match_statement = optional(object({
+                search_string         = string
+                positional_constraint = string
+                field_to_match = object({
+                  uri_path      = optional(bool)
+                  single_header = optional(string)
+                })
+                text_transformation = object({
+                  priority = number
+                  type     = string
+                })
+              }))
+              ip_set_reference_statement = optional(object({
+                arn = string
+              }))
+            }))
+          }))
+          or_statement = optional(object({
+            statements = list(object({
+              byte_match_statement = optional(object({
+                search_string         = string
+                positional_constraint = string
+                field_to_match = object({
+                  uri_path      = optional(bool)
+                  single_header = optional(string)
+                })
+                text_transformation = object({
+                  priority = number
+                  type     = string
+                })
+              }))
+              ip_set_reference_statement = optional(object({
+                arn = string
+              }))
+            }))
+          }))
+        }))
+      }))
     }))
 
     and_statement = optional(object({
@@ -316,8 +429,7 @@ variable "rules" {
     error_message = "managed_rule_group_statement.rule_action_overrides[*].action must be one of: count, allow, block."
   }
 
-  # Validation 5: managed_rule_group_statement.scope_down_statement must specify exactly one of
-  # byte_match_statement, ip_set_reference_statement, and_statement, or_statement, or not_statement.
+  # Validation 5: managed_rule_group_statement.scope_down_statement must specify exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or_statement, or not_statement.
   validation {
     condition = alltrue([
       for v in var.rules :
@@ -330,8 +442,7 @@ variable "rules" {
     ])
     error_message = "managed_rule_group_statement.scope_down_statement must specify exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or_statement, or not_statement."
   }
-  # Validation 6: When scope_down_statement.not_statement is used, exactly one of
-  # byte_match_statement, ip_set_reference_statement, and_statement, or or_statement must be set under it.
+  # Validation 6: When scope_down_statement.not_statement is used, exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or or_statement must be set under it.
   validation {
     condition = alltrue([
       for v in var.rules :
@@ -344,8 +455,7 @@ variable "rules" {
     error_message = "managed_rule_group_statement.scope_down_statement.not_statement must contain exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or or_statement."
   }
 
-  # Validation 7: and_statement / or_statement inside scope_down_statement (directly or under
-  # not_statement) must each contain >= 2 statements.
+  # Validation 7: and_statement / or_statement inside scope_down_statement (directly or under not_statement) must each contain >= 2 statements.
   validation {
     condition = alltrue(flatten([
       for v in var.rules : [
@@ -362,9 +472,7 @@ variable "rules" {
     error_message = "and_statement / or_statement inside scope_down_statement must contain at least 2 statements."
   }
 
-  # Validation 8: each entry in scope_down_statement.and_statement.statements,
-  # scope_down_statement.or_statement.statements, and the same lists under not_statement,
-  # must specify exactly one of byte_match_statement or ip_set_reference_statement.
+  # Validation 8: each entry in scope_down_statement.and_statement.statements, scope_down_statement.or_statement.statements, and the same lists under not_statement, must specify exactly one of byte_match_statement or ip_set_reference_statement.
   validation {
     condition = alltrue(flatten([
       for v in var.rules : [
@@ -382,6 +490,32 @@ variable "rules" {
     ]))
     error_message = "Each statement inside scope_down_statement.and_statement.statements / or_statement.statements (and their not_statement-nested variants) must specify exactly one of byte_match_statement or ip_set_reference_statement."
   }
+
+  # Validation 9: rate_based_statement.scope_down_statement must specify exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or_statement, or not_statement.
+  validation {
+    condition = alltrue([
+      for v in var.rules :
+      (try(v.rate_based_statement.scope_down_statement.byte_match_statement, null) != null ? 1 : 0) +
+      (try(v.rate_based_statement.scope_down_statement.ip_set_reference_statement, null) != null ? 1 : 0) +
+      (try(v.rate_based_statement.scope_down_statement.and_statement, null) != null ? 1 : 0) +
+      (try(v.rate_based_statement.scope_down_statement.or_statement, null) != null ? 1 : 0) +
+      (try(v.rate_based_statement.scope_down_statement.not_statement, null) != null ? 1 : 0) == 1
+      if try(v.rate_based_statement.scope_down_statement, null) != null
+    ])
+    error_message = "rate_based_statement.scope_down_statement must specify exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or_statement, or not_statement."
+  }
+  # Validation 10: When rate_based_statement.scope_down_statement.not_statement is used, exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or or_statement must be set under it.
+  validation {
+    condition = alltrue([
+      for v in var.rules :
+      (try(v.rate_based_statement.scope_down_statement.not_statement.byte_match_statement, null) != null ? 1 : 0) +
+      (try(v.rate_based_statement.scope_down_statement.not_statement.ip_set_reference_statement, null) != null ? 1 : 0) +
+      (try(v.rate_based_statement.scope_down_statement.not_statement.and_statement, null) != null ? 1 : 0) +
+      (try(v.rate_based_statement.scope_down_statement.not_statement.or_statement, null) != null ? 1 : 0) == 1
+      if try(v.rate_based_statement.scope_down_statement.not_statement, null) != null
+    ])
+    error_message = "rate_based_statement.scope_down_statement.not_statement must contain exactly one of byte_match_statement, ip_set_reference_statement, and_statement, or or_statement."
+  }
 }
 
 variable "tags" {
@@ -390,10 +524,7 @@ variable "tags" {
   default     = {}
 }
 
-# ---------------------------------------------------------------------------
 # WAF Logging
-# ---------------------------------------------------------------------------
-
 variable "enable_logging" {
   description = "When true, enables WAF logging to the specified log_destination_arns. The log destination (e.g. CloudWatch log group) must have a name starting with 'aws-waf-logs-'."
   type        = bool

--- a/modules/aws/WAF-Web-ACL/waf_web_acl.tf
+++ b/modules/aws/WAF-Web-ACL/waf_web_acl.tf
@@ -165,6 +165,20 @@ resource "aws_wafv2_web_acl" "web_acl" {
           }
         }
 
+        dynamic "geo_match_statement" {
+          for_each = rule.value.geo_match_statement != null ? [rule.value.geo_match_statement] : []
+          content {
+            country_codes = geo_match_statement.value.country_codes
+            dynamic "forwarded_ip_config" {
+              for_each = geo_match_statement.value.forwarded_ip_config != null ? [geo_match_statement.value.forwarded_ip_config] : []
+              content {
+                header_name       = forwarded_ip_config.value.header_name
+                fallback_behavior = forwarded_ip_config.value.fallback_behavior
+              }
+            }
+          }
+        }
+
         dynamic "managed_rule_group_statement" {
           for_each = rule.value.managed_rule_group_statement != null ? [rule.value.managed_rule_group_statement] : []
           content {
@@ -436,6 +450,242 @@ resource "aws_wafv2_web_acl" "web_acl" {
           content {
             limit              = rate_based_statement.value.limit
             aggregate_key_type = rate_based_statement.value.aggregate_key_type
+
+            dynamic "scope_down_statement" {
+              for_each = try(rate_based_statement.value.scope_down_statement, null) != null ? [rate_based_statement.value.scope_down_statement] : []
+              content {
+                # Direct byte_match_statement
+                dynamic "byte_match_statement" {
+                  for_each = scope_down_statement.value.byte_match_statement != null ? [scope_down_statement.value.byte_match_statement] : []
+                  content {
+                    search_string         = byte_match_statement.value.search_string
+                    positional_constraint = byte_match_statement.value.positional_constraint
+                    field_to_match {
+                      dynamic "uri_path" {
+                        for_each = byte_match_statement.value.field_to_match.uri_path == true ? [1] : []
+                        content {}
+                      }
+                      dynamic "single_header" {
+                        for_each = byte_match_statement.value.field_to_match.single_header != null ? [byte_match_statement.value.field_to_match.single_header] : []
+                        content {
+                          name = single_header.value
+                        }
+                      }
+                    }
+                    text_transformation {
+                      priority = byte_match_statement.value.text_transformation.priority
+                      type     = byte_match_statement.value.text_transformation.type
+                    }
+                  }
+                }
+
+                # Direct ip_set_reference_statement
+                dynamic "ip_set_reference_statement" {
+                  for_each = scope_down_statement.value.ip_set_reference_statement != null ? [scope_down_statement.value.ip_set_reference_statement] : []
+                  content {
+                    arn = ip_set_reference_statement.value.arn
+                  }
+                }
+
+                # Direct and_statement
+                dynamic "and_statement" {
+                  for_each = scope_down_statement.value.and_statement != null ? [scope_down_statement.value.and_statement] : []
+                  content {
+                    dynamic "statement" {
+                      for_each = and_statement.value.statements
+                      content {
+                        dynamic "byte_match_statement" {
+                          for_each = statement.value.byte_match_statement != null ? [statement.value.byte_match_statement] : []
+                          content {
+                            search_string         = byte_match_statement.value.search_string
+                            positional_constraint = byte_match_statement.value.positional_constraint
+                            field_to_match {
+                              dynamic "uri_path" {
+                                for_each = byte_match_statement.value.field_to_match.uri_path == true ? [1] : []
+                                content {}
+                              }
+                              dynamic "single_header" {
+                                for_each = byte_match_statement.value.field_to_match.single_header != null ? [byte_match_statement.value.field_to_match.single_header] : []
+                                content {
+                                  name = single_header.value
+                                }
+                              }
+                            }
+                            text_transformation {
+                              priority = byte_match_statement.value.text_transformation.priority
+                              type     = byte_match_statement.value.text_transformation.type
+                            }
+                          }
+                        }
+                        dynamic "ip_set_reference_statement" {
+                          for_each = statement.value.ip_set_reference_statement != null ? [statement.value.ip_set_reference_statement] : []
+                          content {
+                            arn = ip_set_reference_statement.value.arn
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+
+                # Direct or_statement
+                dynamic "or_statement" {
+                  for_each = scope_down_statement.value.or_statement != null ? [scope_down_statement.value.or_statement] : []
+                  content {
+                    dynamic "statement" {
+                      for_each = or_statement.value.statements
+                      content {
+                        dynamic "byte_match_statement" {
+                          for_each = statement.value.byte_match_statement != null ? [statement.value.byte_match_statement] : []
+                          content {
+                            search_string         = byte_match_statement.value.search_string
+                            positional_constraint = byte_match_statement.value.positional_constraint
+                            field_to_match {
+                              dynamic "uri_path" {
+                                for_each = byte_match_statement.value.field_to_match.uri_path == true ? [1] : []
+                                content {}
+                              }
+                              dynamic "single_header" {
+                                for_each = byte_match_statement.value.field_to_match.single_header != null ? [byte_match_statement.value.field_to_match.single_header] : []
+                                content {
+                                  name = single_header.value
+                                }
+                              }
+                            }
+                            text_transformation {
+                              priority = byte_match_statement.value.text_transformation.priority
+                              type     = byte_match_statement.value.text_transformation.type
+                            }
+                          }
+                        }
+                        dynamic "ip_set_reference_statement" {
+                          for_each = statement.value.ip_set_reference_statement != null ? [statement.value.ip_set_reference_statement] : []
+                          content {
+                            arn = ip_set_reference_statement.value.arn
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+
+                # not_statement wrapping byte_match / ip_set / and / or
+                dynamic "not_statement" {
+                  for_each = scope_down_statement.value.not_statement != null ? [scope_down_statement.value.not_statement] : []
+                  content {
+                    statement {
+                      dynamic "byte_match_statement" {
+                        for_each = not_statement.value.byte_match_statement != null ? [not_statement.value.byte_match_statement] : []
+                        content {
+                          search_string         = byte_match_statement.value.search_string
+                          positional_constraint = byte_match_statement.value.positional_constraint
+                          field_to_match {
+                            dynamic "uri_path" {
+                              for_each = byte_match_statement.value.field_to_match.uri_path == true ? [1] : []
+                              content {}
+                            }
+                            dynamic "single_header" {
+                              for_each = byte_match_statement.value.field_to_match.single_header != null ? [byte_match_statement.value.field_to_match.single_header] : []
+                              content {
+                                name = single_header.value
+                              }
+                            }
+                          }
+                          text_transformation {
+                            priority = byte_match_statement.value.text_transformation.priority
+                            type     = byte_match_statement.value.text_transformation.type
+                          }
+                        }
+                      }
+                      dynamic "ip_set_reference_statement" {
+                        for_each = not_statement.value.ip_set_reference_statement != null ? [not_statement.value.ip_set_reference_statement] : []
+                        content {
+                          arn = ip_set_reference_statement.value.arn
+                        }
+                      }
+                      dynamic "and_statement" {
+                        for_each = not_statement.value.and_statement != null ? [not_statement.value.and_statement] : []
+                        content {
+                          dynamic "statement" {
+                            for_each = and_statement.value.statements
+                            content {
+                              dynamic "byte_match_statement" {
+                                for_each = statement.value.byte_match_statement != null ? [statement.value.byte_match_statement] : []
+                                content {
+                                  search_string         = byte_match_statement.value.search_string
+                                  positional_constraint = byte_match_statement.value.positional_constraint
+                                  field_to_match {
+                                    dynamic "uri_path" {
+                                      for_each = byte_match_statement.value.field_to_match.uri_path == true ? [1] : []
+                                      content {}
+                                    }
+                                    dynamic "single_header" {
+                                      for_each = byte_match_statement.value.field_to_match.single_header != null ? [byte_match_statement.value.field_to_match.single_header] : []
+                                      content {
+                                        name = single_header.value
+                                      }
+                                    }
+                                  }
+                                  text_transformation {
+                                    priority = byte_match_statement.value.text_transformation.priority
+                                    type     = byte_match_statement.value.text_transformation.type
+                                  }
+                                }
+                              }
+                              dynamic "ip_set_reference_statement" {
+                                for_each = statement.value.ip_set_reference_statement != null ? [statement.value.ip_set_reference_statement] : []
+                                content {
+                                  arn = ip_set_reference_statement.value.arn
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                      dynamic "or_statement" {
+                        for_each = not_statement.value.or_statement != null ? [not_statement.value.or_statement] : []
+                        content {
+                          dynamic "statement" {
+                            for_each = or_statement.value.statements
+                            content {
+                              dynamic "byte_match_statement" {
+                                for_each = statement.value.byte_match_statement != null ? [statement.value.byte_match_statement] : []
+                                content {
+                                  search_string         = byte_match_statement.value.search_string
+                                  positional_constraint = byte_match_statement.value.positional_constraint
+                                  field_to_match {
+                                    dynamic "uri_path" {
+                                      for_each = byte_match_statement.value.field_to_match.uri_path == true ? [1] : []
+                                      content {}
+                                    }
+                                    dynamic "single_header" {
+                                      for_each = byte_match_statement.value.field_to_match.single_header != null ? [byte_match_statement.value.field_to_match.single_header] : []
+                                      content {
+                                        name = single_header.value
+                                      }
+                                    }
+                                  }
+                                  text_transformation {
+                                    priority = byte_match_statement.value.text_transformation.priority
+                                    type     = byte_match_statement.value.text_transformation.type
+                                  }
+                                }
+                              }
+                              dynamic "ip_set_reference_statement" {
+                                for_each = statement.value.ip_set_reference_statement != null ? [statement.value.ip_set_reference_statement] : []
+                                content {
+                                  arn = ip_set_reference_statement.value.arn
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
         dynamic "and_statement" {


### PR DESCRIPTION
## Purpose
This pull request introduces three new Terraform modules for AWS CloudFront: `Cloudfront-Function`, `Cloudfront-Response-Headers-Policy`, and `Cloudfront-VPC-Origin`. It also updates the main `Cloudfront` module to support VPC origins and function associations, and includes a small bug fix for hosted zone validation. These changes provide enhanced flexibility for CloudFront deployments, enabling private connectivity to internal resources, custom security headers, and integration of CloudFront Functions.

**New CloudFront Modules:**

*Cloudfront-Function module:*
- Adds a reusable module for deploying AWS CloudFront Functions, including resource definition, input variables, outputs, and version constraints. [[1]](diffhunk://#diff-393c866b682e68103893980cbb7afb690ba2c0d88e5d0b36dbd0bddeec1d27d4R1-R27) [[2]](diffhunk://#diff-67593e841cdd9276f84d422f336206c6f13eb8397129238414fa9d4234b19636R1-R52) [[3]](diffhunk://#diff-b78f44421f909bca634ebc7e80538c297d5f91b484cf15621c14b79afc895fceR1-R34) [[4]](diffhunk://#diff-acf7382ae54339f8d99976c960c97c2634c70c536f149aeba03a652c3d050d00R1-R29)

*Cloudfront-Response-Headers-Policy module:*
- Adds a module to manage CloudFront Response Headers Policies, supporting all security header options, custom headers, input validation, outputs, and version constraints. [[1]](diffhunk://#diff-f925ed6ad36a6c40112dcf685936542b35581d7ba82b4dcff42a5d7a88ac3a6dR1-R91) [[2]](diffhunk://#diff-2fa5ee22d045add6fc6ee1969a5e6767fba90ace77d85bc861e8de5ee3227bd6R1-R101) [[3]](diffhunk://#diff-09a5dd547ab458f91e7072ea89c7c480640633d078b7064e5fcec2f75250f3a0R1-R29) [[4]](diffhunk://#diff-acf7382ae54339f8d99976c960c97c2634c70c536f149aeba03a652c3d050d00R1-R29)

*Cloudfront-VPC-Origin module:*
- Introduces a module to manage CloudFront VPC Origins for private connectivity to internal ALB/NLB/EC2 via AWS-managed ENIs, with variables, outputs, resource definition, and provider constraints. [[1]](diffhunk://#diff-4ad1b14ba78547dee1ca599a2f93ee01e74cfddb97bc626d18bddc0bf78557caR1-R40) [[2]](diffhunk://#diff-3e3c65f5e1a0ecb83d263567d2da31f539e9edcd4b1e3f8196efab7fbdffabf8R1-R59) [[3]](diffhunk://#diff-9af51d8abd71d2d4e7c1aaccf3954542335f1fdefb94563201462c8830f23e9fR1-R29) [[4]](diffhunk://#diff-364569a399a8a54dfa028480da92b267cbe1ddfceafc8e71d30d5589c00ba4e4R1-R29)

**Enhancements to main Cloudfront module:**

- Updates `cloudfront.tf` to support VPC origins (conditional `vpc_origin_config` and `custom_origin_config` blocks) and to allow associating CloudFront Functions with cache behaviors. [[1]](diffhunk://#diff-c0d9452b6e4161627ffa7dad16317ce8ccc5635ea0e410512c75b831b51b8335L26-R45) [[2]](diffhunk://#diff-c0d9452b6e4161627ffa7dad16317ce8ccc5635ea0e410512c75b831b51b8335R93-R100)

**Bug Fix:**

- Fixes a validation bug in `Amazon-Issued-ACM-Certificate/variables.tf` to avoid evaluating `trimspace` on a null value for `hosted_zone_id`.